### PR TITLE
Update deployment maven target from bazel-test-snapshot to spanshot, …

### DIFF
--- a/dependencies/maven/dependencies.yaml
+++ b/dependencies/maven/dependencies.yaml
@@ -153,15 +153,3 @@ dependencies:
     protobuf-java:
       version: 3.5.1
       lang: java
-#
-#
-#
-#replacements:
-#  ai.grakn:
-#    client-java:
-#      lang: java
-#      target: "//dependencies/grakn_local:grakn-client-java"
-#
-#    grakn-graql:
-#      lang: java
-#      target: "//dependencies/grakn_local:grakn-graql"

--- a/deployment.properties
+++ b/deployment.properties
@@ -17,5 +17,5 @@
 #
 
 github.repository=benchmark
-maven.repository-url.snapshot=http://maven.grakn.ai/nexus/content/repositories/bazel-test-snapshot
-maven.repository-url.release=http://maven.grakn.ai/nexus/content/repositories/bazel-test-release
+maven.repository-url.snapshot=http://maven.grakn.ai/nexus/content/repositories/snapshots
+maven.repository-url.release=http://maven.grakn.ai/nexus/content/repositories/releases


### PR DESCRIPTION
Change from `http://maven.grakn.ai/nexus/content/repositories/bazel-test-snapshot` to `http://maven.grakn.ai/nexus/content/repositories/snapshots` for deployment.


Remove commented replacement dependencies