### PR TITLE
Restructured README.md for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,52 @@
-# Benchmarking
+# Benchmark
 
-To get started, Grakn, Ignite, Elasticsearch and Zipkin need to be running.
+Benchmarks is a software used for measuring the performance of Grakn. It supports two main use cases:
 
-## Elasticsearch
-https://www.elastic.co/guide/en/elasticsearch/reference/6.3/zip-targz.html
+1. Benchmarking (done using the `runner` package)
+2. Visualising the benchmark result (done using the `dashboard` package)
 
-In the elasticsearch installation directory, do:
+## Requirements
+
+1. [Download Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/6.3/zip-targz.html)
+
+2. [Download Zipkin](https://github.com/openzipkin/zipkin/blob/master/zipkin-server/README.md)
+
+3. Install `pipenv`
+
+4. Install the requirements of `benchmark-dashboard`: 
+
+   ```
+   $ cd $BENCHMARK/dashboard
+   $ pipenv install
+   ```
+
+## Using Benchmark
+
+### 1. Start Elasticsearch & Zipkin
+
+In the Elasticsearch installation directory, do:
 ```
-./bin/elasticsearch -E path.logs=[REPOSITORY_PATH]/data/logs/elasticsearch/ -E path.data=[REPOSITORY_PATH]/data/data/elasticsearch/
+$ ./bin/elasticsearch -E path.logs=<REPOSITORY_PATH>/data/logs/elasticsearch/ -E path.data=<REPOSITORY_PATH>/data/data/elasticsearch/
 ```
 
-## Zipkin
-https://github.com/openzipkin/zipkin/blob/master/zipkin-server/README.md
+Check if Elasticsearch is running by accessing http://localhost:9200 from the browser.
 
-In the zipkin installation directory, do:
+In the Zipkin installation directory, do:
 
 ```
-STORAGE_TYPE=elasticsearch ES_HOSTS=http://localhost:9200 ES_INDEX="benchmarking" java -jar zipkin.jar
+$ STORAGE_TYPE=elasticsearch ES_HOSTS=http://localhost:9200 ES_INDEX="benchmarking" java -jar zipkin.jar
 ```
-The above connects to a running Elasticsearch backend, which persists benchmarking data
+Check if Zipkin is running by accessing http://localhost:9411/zipkin/ from the browser.
 
-To start without using Elasticsearch, do:
+**NOTE**: For development purpose, you may find it easier to start Zipkin backed with an in-memory store as opposed to ElasticSearch:
+
 ```
-java -jar zipkin.jar
+$ java -jar zipkin.jar
 ```
 
-Access zipkin to see the spans recorded at: http://localhost:9411/zipkin/
 
-Check elasticsearch is running by receiving a response from http://localhost:9200 in-browser
 
-## Plotly Dashboard
-
-The visualisation dashboard reads ElasticSearch and creates graphs via Dash and Plotly.
-
-Getting it up and running requires pipenv and python >=3.6.0
-
-1. `pipenv install` (installs package dependencies for the dashboard)
-2. `pipenv shell` (may need to modify the `python_version = "3.6"` if the python version is newer/not quite the same. Alternatively manage the python version with `pyenv`.
-3. In the `dashboard/` directory, run `python dashboard.py`
-4. Navigate to `http:localhost:8050` to see the dashboard
-
-The box plots are individually clickable to drill down, bar charts (default if only 1 repetition is being displayed) cycle through drill downs on each click.
-
-## Executing Benchmarks and Generating Data
+### 2. Benchmark Grakn With Benchmark-Runner
 
 We define YAML config files to execute under `benchmark/runner/conf/somedir`
 
@@ -52,14 +56,13 @@ Basic usage:
 `run.py --config grakn-benchmark/src/main/resources/societal_config_1.yml --execution-name query-plan-mod-1 --keyspace benchmark --ignite-dir /Users/user/Documents/benchmarking-reqs/apache-ignite-fabric-2.6.0-bin/`
 
 Notes:
-* Naming the execution not required, default name is always prepended with current Date and `name` tag in the YAML file
-* Keyspace is not required, defaults to `name` in the YAML file
+
+- Naming the execution not required, default name is always prepended with current Date and `name` tag in the YAML file
+- Keyspace is not required, defaults to `name` in the YAML file
 
 Further examples:
 
-
 ** TODO revisit run.py to see if it is needed all, was primarily intended to collect classpath, Bazel now does already **
-
 
 Stop and re-unpack Grakn server, then run
 `run.py --unpack-tar --config grakn-benchmark/src/main/resources/societal_config_1.yml`
@@ -70,12 +73,12 @@ Rebuild Grakn server, stop and remove the old one, untar, then run
 Rebuild Benchmarking and its dependencies and execute
 `run.py --build-benchmark--alldeps --config grakn-benchmark/src/main/resources/societal_config_1.yml`
 
+#### Adding new spans to measure code segments
 
-### Adding new spans to measure code segments
-
-* On the server, the intended usage is as follows:
+- On the server, the intended usage is as follows:
 
 Then add a child span that propogates in thread-local storage
+
 ```
     ScopedSpan childSpan = null;
     if (ServerTracingInstrumentation.tracingActive()) {
@@ -89,28 +92,30 @@ Then add a child span that propogates in thread-local storage
     }
 ```
 
-
 Some packages in `grakn.core` are not currently depending on `benchmark.lib` which contains the instrumentation.
 In the `dependencies.yaml` make sure
+
 ```
 ai.grakn:
     benchmark.lib:
         version: ...
         lang: java
 ```
+
 is present, and in the BUILD file this dependency is referenced.
 
 
 
+### 3. Visualise Results In Benchmark-Dashboard
 
-## Kibana
-Kibana can be used for visualization, however we've since designed a dashboard using Plotly.
+The visualisation dashboard reads ElasticSearch and creates graphs via Dash and Plotly.
 
-https://www.elastic.co/guide/en/kibana/current/setup.html
+Getting it up and running requires `pipenv` and Python >=3.6.0
 
-In the Kibana installation directory, do:
+1. `pipenv shell` (may need to modify the `python_version = "3.6"` if the python version is newer/not quite the same. Alternatively manage the python version with `pyenv`.
+2. In the `dashboard/` directory, run `python dashboard.py`
+3. Navigate to `http:localhost:8050` to see the dashboard
 
-./bin/kibana
+The box plots are individually clickable to drill down, bar charts (default if only 1 repetition is being displayed) cycle through drill downs on each click.
 
-Access at:
-http://localhost:5601
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Benchmark
 
-Benchmarks is a software used for measuring the performance of Grakn. It supports two main use cases:
+Benchmark is a piece of software used for measuring the performance of Grakn. It supports two main use cases:
 
 1. Benchmarking (done using the `runner` package)
 2. Visualising the benchmark result (done using the `dashboard` package)


### PR DESCRIPTION
Restructured README.md for readability. Now it contains three top-level sections:
1. description (what benchmark is)
2. installing pre-requisites, both required at compile time (pipenv) and runtime (ES, Zipkin)
3. running the software
  - start ES and Zipkin
  - benchmarking Grakn with runner
  - visualising the result in the dashboard

Remove the Kibana section as we're not planning to our user to use it.