### PR TITLE
Benchmark runner distribution

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -42,5 +42,8 @@ distribution(
         "data/logs",
         "data/data"
     ],
+    permissions = {
+        "runner/runner.sh": "0755"
+    },
     output_filename = "benchmark-runner",
 )

--- a/BUILD
+++ b/BUILD
@@ -17,3 +17,30 @@
 #
 
 exports_files(["VERSION", "deployment.properties"], visibility = ["//visibility:public"])
+
+# TODO: the distribution only includes 'benchmark-runner'. Need to add 'benchmark-dashboard'.
+load("@graknlabs_rules_deployment//distribution:rules.bzl", distribution = "distribution")
+distribution(
+    name = "distribution",
+    targets = {
+        "//runner:benchmark-runner": "runner/services/lib/",
+    },
+    additional_files = {
+        "//runner:runner.sh": "runner/runner.sh",
+        "//runner:conf/societal_model/queries.yml": "runner/conf/societal_model/queries.yml",
+        "//runner:conf/societal_model/societal_config_1.yml": "runner/conf/societal_model/societal_config_1.yml",
+        "//runner:conf/societal_model/societal_model.gql": "runner/conf/societal_model/societal_model.gql",
+        "//runner:conf/web_content/queries.yml": "runner/conf/web_content/queries.yml",
+        "//runner:conf/web_content/web_content_config.yml": "runner/conf/web_content/web_content_config.yml",
+        "//runner:conf/web_content/web_content_schema.gql": "runner/conf/web_content/web_content_schema.gql",
+        
+        # External dependencies: Elasticsearch and Zipkin
+        "@external-dependencies-zipkin//file": "external-dependencies/zipkin.jar",
+        "@external-dependencies-elasticsearch//file": "external-dependencies/elasticsearch.zip"
+    },
+    empty_directories = [
+        "data/logs",
+        "data/data"
+    ],
+    output_filename = "benchmark-runner",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,6 +18,26 @@
 
 workspace(name = "benchmark")
 
+############################
+# Load Common Dependencies #
+############################
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+
+####################
+# Load Build Tools #
+####################
+# Load additional build tools, such bazel-deps and unused-deps
+load("//dependencies/tools:dependencies.bzl", "tools_dependencies")
+tools_dependencies()
+
+
+#####################################
+# Load Java dependencies from Maven #
+#####################################
+load("//dependencies/maven:dependencies.bzl", "maven_dependencies")
+maven_dependencies()
+
 # TODO remove this when graknlabs/benchmark issue #58 is resolved
 # (this shouldn't have to be stated here?)
 git_repository(
@@ -26,18 +46,33 @@ git_repository(
     tag = "0.1.0",  # change this to use a different release
 )
 
-# Load additional build tools, such bazel-deps and unused-deps
-load("//dependencies/tools:dependencies.bzl", "tools_dependencies")
-tools_dependencies()
-
-
-load("//dependencies/maven:dependencies.bzl", "maven_dependencies")
-maven_dependencies()
-
+##############################################
+# Load External Dependencies - ES and Zipkin #
+##############################################
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+http_file(
+  name = "external-dependencies-zipkin",
+  sha256 = "0c7374621e751b6f5b70b3bc6cf43f2d105f3e2337c78a0fa571b2263704c9e5",
+  urls = [
+    "https://dl.bintray.com/openzipkin/maven/io/zipkin/java/zipkin-server/2.11.12/zipkin-server-2.11.12-exec.jar"
+  ],
+)
+http_file(
+  name = "external-dependencies-elasticsearch",
+  sha256 = "126b83ec1163dba1551491828b9b5f5c456d62f6e731159da045b46570295e38",
+  urls = [
+    "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.3.2.zip"
+  ],
+)
 
 ########################################
 #     Load Deployment Dependencies     #
 ########################################
+git_repository(
+    name="graknlabs_rules_deployment",
+    remote="https://github.com/lolski/deployment",
+    commit="c3130f67269548f1ab2647454e8640b0a54ede57",
+)
 
 load("//dependencies/deployment/maven:dependencies.bzl", maven_dependencies_for_deployment = "maven_dependencies")
 maven_dependencies_for_deployment()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -70,8 +70,8 @@ http_file(
 ########################################
 git_repository(
     name="graknlabs_rules_deployment",
-    remote="https://github.com/lolski/deployment",
-    commit="c3130f67269548f1ab2647454e8640b0a54ede57",
+    remote="https://github.com/graknlabs/deployment",
+    commit="1fd6f328d55b28ca70b047894917cb169d5f028e",
 )
 
 load("//dependencies/deployment/maven:dependencies.bzl", maven_dependencies_for_deployment = "maven_dependencies")

--- a/runner/BUILD
+++ b/runner/BUILD
@@ -16,6 +16,14 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+exports_files(glob(["conf/**/*"]) + ["runner.sh"], visibility = ["//visibility:public"])
+
+java_binary(
+    name = "benchmark-runner-binary",
+    main_class = "grakn.benchmark.runner.BenchmarkRunner",
+    runtime_deps = ["//runner:benchmark-runner"],
+    visibility = ["//visibility:public"]
+ )
 
 java_library(
     name = "benchmark-runner",
@@ -52,17 +60,9 @@ java_library(
 
     resources = [
         "//runner:src/logback.xml"
-    ]
-)
-
-java_binary(
-    name = "benchmark-runner-binary",
-    main_class = "grakn.benchmark.runner.BenchmarkRunner",
-    runtime_deps = ["//runner:benchmark-runner"],
+    ],
     visibility = ["//visibility:public"]
 )
-
-
 
 java_test(
     name = "ignite-conceptid-store-test",

--- a/runner/runner.sh
+++ b/runner/runner.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+set -e
+
+# Benchmark global variables
+JAVA_BIN=java
+[[ $(readlink $0) ]] && path=$(readlink $0) || path=$0
+BENCHMARK_HOME=$(cd "$(dirname "${path}")" && pwd -P)
+
+SERVICE_LIB_CP="services/lib/*"
+
+# ================================================
+# common helper functions
+# ================================================
+exit_if_java_not_found() {
+  which "${JAVA_BIN}" > /dev/null
+  exit_code=$?
+
+  if [[ $exit_code -ne 0 ]]; then
+    echo "Java is not installed on this machine. Benchmark needs Java 1.8 in order to run."
+    exit 1
+  fi
+}
+
+# =============================================
+# main routine
+# =============================================
+
+exit_code=0
+
+pushd "$BENCHMARK_HOME" > /dev/null
+exit_if_java_not_found
+
+echo "Starting Elasticsearch..."
+./external-dependencies/elasticsearch-6.3.2/./bin/elasticsearch -E path.logs=data/logs/elasticsearch/ -E path.data=data/data/elasticsearch/ &
+sleep 10
+
+echo "Starting Zipkin"
+ES_HOSTS=http://localhost:9200 env ES_INDEX="benchmarking" java -jar ./external-dependencies/zipkin.jar &
+
+echo "Starting Benchmark Runner"
+CLASSPATH="${BENCHMARK_HOME}/${SERVICE_LIB_CP}"
+java -cp "${CLASSPATH}" grakn.benchmark.runner.BenchmarkRunner $@
+
+exit_code=$?
+
+popd > /dev/null
+
+exit $exit_code


### PR DESCRIPTION
# Added support for building Benchmark
Added the ability to build benchmark distribution. It contains `benchmark-runner`, Elasticsearch, and Zipkin.

Elasticsearch and Zipkin are bundled to make the life of user who wants to run them easier - they don't have to deal with the small steps you normally would:
  - downloading and installing the correct Elasticsearch and Zipkin from the website
  - starting benchmark while making sure to provide the correct path / ports
  - starting Elasticsearch, Zipkin, and Benchmark one by one

This is how we use it:
```
$ bazel build //:distribution # the zip will be in bazel-genfiles/benchmark.zip
```
# Updated benchmark-runner script
`benchmark-runner` can be started like so (as I remember from a discussion with @flyingsilverfin there's a limitation where we need to provide the config.yml's full path and not relative path):
```
$ runner/runner.sh -c /Users/lolski/grakn.ai/benchmark/bazel-genfiles/benchmark-runner/runner/conf/societal_model/societal_config_1.yml
```

# Future Improvements
1. Right now Elasticsearch is bundled as a zip within the distribution zip (a zip within a zip). This is because our distribution rule is limited and can't handle such scenario.
2. The `runner.sh` script expect things work according to happy paths.