### PR TITLE
Redefine Graph Scale in Data Generator

### DIFF
--- a/runner/BUILD
+++ b/runner/BUILD
@@ -73,6 +73,8 @@ java_test(
         ":benchmark-runner",
         "//dependencies/maven/artifacts/org/mockito:mockito-core",
         "//dependencies/maven/artifacts/grakn/core:grakn-graql",
+        "//dependencies/maven/artifacts/org/apache/ignite:ignite-core",
+        "//dependencies/maven/artifacts/org/apache/ignite:ignite-indexing"
     ]
 )
 

--- a/runner/conf/societal_model/societal_config_1.yml
+++ b/runner/conf/societal_model/societal_config_1.yml
@@ -1,7 +1,7 @@
 name: "societal model"
 schema: "societal_model.gql"
 queries: "queries.yml"
-concepts:
+scales:
   - 40000
 repeatsPerQuery: 0
 # TODO

--- a/runner/conf/web_content/web_content_config.yml
+++ b/runner/conf/web_content/web_content_config.yml
@@ -1,7 +1,7 @@
 name: "web content"
 schema: "web_content_schema.gql"
 queries: "queries.yml"
-concepts:
+scales:
   - 2000
 repeatsPerQuery: 0
 # TODO

--- a/runner/conf/web_content/web_content_config.yml
+++ b/runner/conf/web_content/web_content_config.yml
@@ -2,7 +2,7 @@ name: "web content"
 schema: "web_content_schema.gql"
 queries: "queries.yml"
 concepts:
-  - 20000
+  - 2000
 repeatsPerQuery: 0
 # TODO
 # concurrency:

--- a/runner/src/BenchmarkRunner.java
+++ b/runner/src/BenchmarkRunner.java
@@ -94,7 +94,7 @@ public class BenchmarkRunner {
             // only 1 point to profile at
             this.queryExecutor.processStaticQueries(numQueryRepetitions, numConcepts, "Preconfigured DB - no data gen");
         } else {
-            this.runAtConcepts(this.configuration.getConceptsToBenchmark());
+            this.runAtConcepts(this.configuration.scalesToProfile());
         }
 
     }
@@ -102,13 +102,13 @@ public class BenchmarkRunner {
     /**
      * Given a list of database sizes to perform profiling at,
      * Populate the DB to a given size, then run the benchmark
-     * @param numConceptsInRun
+     * @param scalesToProfile
      */
-    private void runAtConcepts(List<Integer> numConceptsInRun) {
-        for (int numConcepts : numConceptsInRun) {
-            LOG.info("Running queries with " + Integer.toString(numConcepts) + " concepts");
-            this.dataGenerator.generate(numConcepts);
-            this.queryExecutor.processStaticQueries(numQueryRepetitions, numConcepts);
+    private void runAtConcepts(List<Integer> scalesToProfile) {
+        for (int scale : scalesToProfile) {
+            LOG.info("Running queries with " + Integer.toString(scale) + " vertices");
+            this.dataGenerator.generate(scale);
+            this.queryExecutor.processStaticQueries(numQueryRepetitions, scale);
         }
     }
 

--- a/runner/src/executionconfig/BenchmarkConfiguration.java
+++ b/runner/src/executionconfig/BenchmarkConfiguration.java
@@ -94,11 +94,11 @@ public class BenchmarkConfiguration {
         return this.queries.getQueries();
     }
 
-    public List<Integer> getConceptsToBenchmark() {
+    public List<Integer> scalesToProfile() {
         if (this.noDataGeneration) {
             return null;
         } else {
-            return this.benchmarkConfigFile.getConceptsToBenchmark();
+            return this.benchmarkConfigFile.scalesToProfile();
         }
     }
 

--- a/runner/src/executionconfig/BenchmarkConfigurationFile.java
+++ b/runner/src/executionconfig/BenchmarkConfigurationFile.java
@@ -29,7 +29,7 @@ public class BenchmarkConfigurationFile {
     private String name;
     private String schema;
     private String queries;
-    private List<Integer> concepts;
+    private List<Integer> scalesToProfile;
     private Integer repeatsPerQuery;
 
     public void setName(String name) {
@@ -53,11 +53,11 @@ public class BenchmarkConfigurationFile {
         return this.queries;
     }
 
-    public void setConcepts(List<Integer> concepts) {
-        this.concepts = concepts;
+    public void setScales(List<Integer> scales) {
+        this.scalesToProfile = scales;
     }
-    public List<Integer> getConceptsToBenchmark() {
-        return this.concepts;
+    public List<Integer> scalesToProfile() {
+        return this.scalesToProfile;
     }
 
     public void setRepeatsPerQuery(Integer repeatsPerQuery) {

--- a/runner/src/generator/AttributeGenerator.java
+++ b/runner/src/generator/AttributeGenerator.java
@@ -46,7 +46,6 @@ public class AttributeGenerator<OwnerDatatype, ValueDatatype> extends Generator<
      */
     public AttributeGenerator(AttributeStrategy<OwnerDatatype, ValueDatatype> strategy, Grakn.Transaction tx) {
         super(strategy, tx);
-
     }
 
     /**
@@ -55,7 +54,6 @@ public class AttributeGenerator<OwnerDatatype, ValueDatatype> extends Generator<
     @Override
     public Stream<Query> generate() {
 
-        // TODO 2 lines common to all 3 generators
         QueryBuilder qb = this.tx.graql();
         int numInstances = this.strategy.getNumInstancesPDF().sample();
 

--- a/runner/src/generator/DataGenerator.java
+++ b/runner/src/generator/DataGenerator.java
@@ -83,7 +83,7 @@ public class DataGenerator {
         this.initialized = true;
     }
 
-    public void generate(int numConceptsLimit) {
+    public void generate(int graphScaleLimit) {
         if (!this.initialized) {
             throw new GeneratorUninitializedException("generate() can only be called after initializing the generation strategies");
         }
@@ -97,7 +97,7 @@ public class DataGenerator {
         GeneratorFactory gf = new GeneratorFactory();
         int graphSize = getGraphSize();
 
-        while (graphSize < numConceptsLimit) {
+        while (graphSize < graphScaleLimit) {
             System.out.printf("\n---- Iteration %d ----\n", this.iteration);
             try (Grakn.Transaction tx = session.transaction(GraknTxType.WRITE)) {
 

--- a/runner/src/generator/DataGenerator.java
+++ b/runner/src/generator/DataGenerator.java
@@ -95,7 +95,7 @@ public class DataGenerator {
         */
 
         GeneratorFactory gf = new GeneratorFactory();
-        int graphSize = getGraphSize();
+        int graphSize = dataStrategies.getGraphScale();
 
         while (graphSize < graphScaleLimit) {
             System.out.printf("\n---- Iteration %d ----\n", this.iteration);
@@ -115,7 +115,7 @@ public class DataGenerator {
                 this.processQueryStream(queryStream);
 
                 iteration++;
-                graphSize = getGraphSize();
+                graphSize = dataStrategies.getGraphScale();
                 System.out.printf(String.format("Size: %d (based on ignite data)\n", graphSize));
                 System.out.println(String.format("   %d role players", this.storage.totalRolePlayers()));
                 System.out.println(String.format("   %d entity orphans", this.storage.totalOrphanEntities()));
@@ -148,10 +148,4 @@ public class DataGenerator {
                 });
     }
 
-    private int getGraphSize() {
-        int rolePlayers = storage.totalRolePlayers();
-        int orphanEntities = storage.totalOrphanEntities();
-        int orphanAttributes = storage.totalOrphanAttributes();
-        return rolePlayers + orphanAttributes + orphanEntities;
-    }
 }

--- a/runner/src/generator/DataGenerator.java
+++ b/runner/src/generator/DataGenerator.java
@@ -110,8 +110,10 @@ public class DataGenerator {
                 GeneratorInterface generator = gf.create(typeStrategy, tx); // TODO Can we do without creating a new generator each iteration
 
                 System.out.println("Using generator " + generator.getClass().toString());
+                // create the stream of insert/match-insert queries
                 Stream<Query> queryStream = generator.generate();
-                
+
+                // execute & parse the results
                 this.processQueryStream(queryStream);
 
                 iteration++;

--- a/runner/src/generator/DataGenerator.java
+++ b/runner/src/generator/DataGenerator.java
@@ -22,10 +22,7 @@ import grakn.benchmark.runner.schemaspecific.SchemaSpecificDataGenerator;
 import grakn.benchmark.runner.schemaspecific.SchemaSpecificDataGeneratorFactory;
 import grakn.core.GraknTxType;
 import grakn.core.client.Grakn;
-import grakn.core.concept.AttributeType;
-import grakn.core.concept.Concept;
-import grakn.core.concept.EntityType;
-import grakn.core.concept.RelationshipType;
+import grakn.core.concept.*;
 import grakn.core.graql.InsertQuery;
 import grakn.core.graql.Query;
 import grakn.core.graql.answer.ConceptMap;
@@ -39,6 +36,7 @@ import grakn.benchmark.runner.strategy.TypeStrategyInterface;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -118,10 +116,12 @@ public class DataGenerator {
 
                 iteration++;
                 graphSize = getGraphSize();
-                System.out.printf(String.format("---- %d concepts (based on ignite data):----\n", graphSize), this.iteration);
-//                System.out.println(String.format("   %d entities", this.storage.totalEntities()));
-//                System.out.println(String.format("   %d relationships", this.storage.totalRelationships()));
-//                System.out.println(String.format("   %d attributes", this.storage.totalAttributes()));
+                System.out.printf(String.format("Size: %d (based on ignite data)\n", graphSize));
+                System.out.println(String.format("   %d role players", this.storage.totalRolePlayers()));
+                System.out.println(String.format("   %d entity orphans", this.storage.totalOrphanEntities()));
+                System.out.println(String.format("   %d attribute orphans", this.storage.totalOrphanAttributes()));
+                System.out.println(String.format("   %d Rel double counts", this.storage.totalRelationshipsRolePlayersOverlap()));
+                System.out.println(String.format("   %d Relationships", this.storage.totalRelationships()));
 
                 tx.commit();
             }
@@ -141,6 +141,9 @@ public class DataGenerator {
                             throw new RuntimeException("No concepts were inserted");
                         }
                         insertedConcepts.forEach(concept -> this.storage.addConcept(concept));
+
+                        Set<ConceptId> rolePlayers = InsertionAnalysis.getRolePlayers(q);
+                        rolePlayers.forEach(conceptId -> this.storage.addRolePlayer(conceptId.toString()));
                     });
                 });
     }

--- a/runner/src/generator/DataGenerator.java
+++ b/runner/src/generator/DataGenerator.java
@@ -95,9 +95,9 @@ public class DataGenerator {
         */
 
         GeneratorFactory gf = new GeneratorFactory();
-        int graphSize = dataStrategies.getGraphScale();
+        int graphScale= dataStrategies.getGraphScale();
 
-        while (graphSize < graphScaleLimit) {
+        while (graphScale < graphScaleLimit) {
             System.out.printf("\n---- Iteration %d ----\n", this.iteration);
             try (Grakn.Transaction tx = session.transaction(GraknTxType.WRITE)) {
 
@@ -115,8 +115,8 @@ public class DataGenerator {
                 this.processQueryStream(queryStream);
 
                 iteration++;
-                graphSize = dataStrategies.getGraphScale();
-                System.out.printf(String.format("Size: %d (based on ignite data)\n", graphSize));
+                graphScale = dataStrategies.getGraphScale();
+                System.out.printf(String.format("Size: %d (based on ignite data)\n", graphScale));
                 System.out.println(String.format("   %d role players", this.storage.totalRolePlayers()));
                 System.out.println(String.format("   %d entity orphans", this.storage.totalOrphanEntities()));
                 System.out.println(String.format("   %d attribute orphans", this.storage.totalOrphanAttributes()));

--- a/runner/src/generator/DataGenerator.java
+++ b/runner/src/generator/DataGenerator.java
@@ -147,8 +147,8 @@ public class DataGenerator {
 
     private int getGraphSize() {
         int rolePlayers = storage.totalRolePlayers();
-        int orphanEntities = storage.totalOrpanEntities();
-        int orphanAttributes = storage.totalOrphanAttributeValues();
+        int orphanEntities = storage.totalOrphanEntities();
+        int orphanAttributes = storage.totalOrphanAttributes();
         return rolePlayers + orphanAttributes + orphanEntities;
     }
 }

--- a/runner/src/generator/DataGenerator.java
+++ b/runner/src/generator/DataGenerator.java
@@ -97,9 +97,9 @@ public class DataGenerator {
         */
 
         GeneratorFactory gf = new GeneratorFactory();
-        int conceptTotal = this.storage.total();
+        int graphSize = getGraphSize();
 
-        while (conceptTotal < numConceptsLimit) {
+        while (graphSize < numConceptsLimit) {
             System.out.printf("\n---- Iteration %d ----\n", this.iteration);
             try (Grakn.Transaction tx = session.transaction(GraknTxType.WRITE)) {
 
@@ -117,11 +117,11 @@ public class DataGenerator {
                 this.processQueryStream(queryStream);
 
                 iteration++;
-                conceptTotal = this.storage.total();
-                System.out.printf(String.format("---- %d concepts (based on ignite data):----\n", conceptTotal), this.iteration);
-                System.out.println(String.format("   %d entities", this.storage.totalEntities()));
-                System.out.println(String.format("   %d relationships", this.storage.totalRelationships()));
-                System.out.println(String.format("   %d attributes", this.storage.totalAttributes()));
+                graphSize = getGraphSize();
+                System.out.printf(String.format("---- %d concepts (based on ignite data):----\n", graphSize), this.iteration);
+//                System.out.println(String.format("   %d entities", this.storage.totalEntities()));
+//                System.out.println(String.format("   %d relationships", this.storage.totalRelationships()));
+//                System.out.println(String.format("   %d attributes", this.storage.totalAttributes()));
 
                 tx.commit();
             }
@@ -140,8 +140,15 @@ public class DataGenerator {
                         if (insertedConcepts.isEmpty()) {
                             throw new RuntimeException("No concepts were inserted");
                         }
-                        insertedConcepts.forEach(concept -> this.storage.add(concept));
+                        insertedConcepts.forEach(concept -> this.storage.addConcept(concept));
                     });
                 });
+    }
+
+    private int getGraphSize() {
+        int rolePlayers = storage.totalRolePlayers();
+        int orphanEntities = storage.totalOrpanEntities();
+        int orphanAttributes = storage.totalOrphanAttributeValues();
+        return rolePlayers + orphanAttributes + orphanEntities;
     }
 }

--- a/runner/src/schemaspecific/SchemaSpecificDataGenerator.java
+++ b/runner/src/schemaspecific/SchemaSpecificDataGenerator.java
@@ -1,9 +1,19 @@
 package grakn.benchmark.runner.schemaspecific;
 
+import grakn.benchmark.runner.storage.ConceptStore;
 import grakn.benchmark.runner.strategy.RouletteWheel;
 import grakn.benchmark.runner.strategy.TypeStrategyInterface;
 
 
 public interface SchemaSpecificDataGenerator {
     RouletteWheel<RouletteWheel<TypeStrategyInterface>> getStrategy();
+
+    ConceptStore getConceptStore();
+    default int getGraphScale() {
+        ConceptStore storage = getConceptStore();
+        int rolePlayers = storage.totalRolePlayers();
+        int orphanEntities = storage.totalOrphanEntities();
+        int orphanAttributes = storage.totalOrphanAttributes();
+        return rolePlayers + orphanAttributes + orphanEntities;
+    }
 }

--- a/runner/src/schemaspecific/SocietalModelGenerator.java
+++ b/runner/src/schemaspecific/SocietalModelGenerator.java
@@ -104,7 +104,7 @@ public class SocietalModelGenerator implements SchemaSpecificDataGenerator {
                 0.3,
                 new RelationshipStrategy(
                         "employment",
-                        new ScalingDiscreteGaussian(random, ()->storage.totalEntities(), 0.5, 0.25),
+                        new ScalingDiscreteGaussian(random, ()->getGraphSize(), 0.5, 0.25),
                         employmentRoleStrategies)
         );
 
@@ -126,7 +126,7 @@ public class SocietalModelGenerator implements SchemaSpecificDataGenerator {
                 1.0,
                 new AttributeStrategy<>(
                         "name",
-                        new ScalingUniform(random, ()->storage.totalEntities(), 0.75,1.25),
+                        new ScalingUniform(random, ()->getGraphSize(), 0.75,1.25),
                         new AttributeOwnerTypeStrategy<>(
                                 "company",
                                 new StreamProvider<>(
@@ -207,7 +207,7 @@ public class SocietalModelGenerator implements SchemaSpecificDataGenerator {
                 5.0,
                 new AttributeStrategy<>(
                         "rating",
-                        new ScalingUniform(random, ()->storage.totalEntities(),0.1, 1.0),
+                       new ScalingUniform(random, ()->getGraphSize(),0.1, 1.0),
                         new AttributeOwnerTypeStrategy<>(
                                 "company",
                                 new StreamProvider<>(
@@ -248,6 +248,14 @@ public class SocietalModelGenerator implements SchemaSpecificDataGenerator {
         this.operationStrategies.add(0.2, this.relationshipStrategies);
         this.operationStrategies.add(0.2, this.attributeStrategies);
 
+    }
+
+
+    private int getGraphSize() {
+        int rolePlayers = storage.totalRolePlayers();
+        int orphanEntities = storage.totalOrpanEntities();
+        int orphanAttributes = storage.totalOrphanAttributeValues();
+        return rolePlayers + orphanAttributes + orphanEntities;
     }
 
 }

--- a/runner/src/schemaspecific/SocietalModelGenerator.java
+++ b/runner/src/schemaspecific/SocietalModelGenerator.java
@@ -104,7 +104,7 @@ public class SocietalModelGenerator implements SchemaSpecificDataGenerator {
                 0.3,
                 new RelationshipStrategy(
                         "employment",
-                        new ScalingDiscreteGaussian(random, ()->getGraphSize(), 0.5, 0.25),
+                        new ScalingDiscreteGaussian(random, ()->getGraphScale(), 0.5, 0.25),
                         employmentRoleStrategies)
         );
 
@@ -126,7 +126,7 @@ public class SocietalModelGenerator implements SchemaSpecificDataGenerator {
                 1.0,
                 new AttributeStrategy<>(
                         "name",
-                        new ScalingUniform(random, ()->getGraphSize(), 0.75,1.25),
+                        new ScalingUniform(random, ()->getGraphScale(), 0.75,1.25),
                         new AttributeOwnerTypeStrategy<>(
                                 "company",
                                 new StreamProvider<>(
@@ -207,7 +207,7 @@ public class SocietalModelGenerator implements SchemaSpecificDataGenerator {
                 5.0,
                 new AttributeStrategy<>(
                         "rating",
-                       new ScalingUniform(random, ()->getGraphSize(),0.1, 1.0),
+                       new ScalingUniform(random, ()->getGraphScale(),0.1, 1.0),
                         new AttributeOwnerTypeStrategy<>(
                                 "company",
                                 new StreamProvider<>(
@@ -251,11 +251,8 @@ public class SocietalModelGenerator implements SchemaSpecificDataGenerator {
     }
 
 
-    private int getGraphSize() {
-        int rolePlayers = storage.totalRolePlayers();
-        int orphanEntities = storage.totalOrphanEntities();
-        int orphanAttributes = storage.totalOrphanAttributes();
-        return rolePlayers + orphanAttributes + orphanEntities;
+    public ConceptStore getConceptStore() {
+        return this.storage;
     }
 
 }

--- a/runner/src/schemaspecific/SocietalModelGenerator.java
+++ b/runner/src/schemaspecific/SocietalModelGenerator.java
@@ -253,8 +253,8 @@ public class SocietalModelGenerator implements SchemaSpecificDataGenerator {
 
     private int getGraphSize() {
         int rolePlayers = storage.totalRolePlayers();
-        int orphanEntities = storage.totalOrpanEntities();
-        int orphanAttributes = storage.totalOrphanAttributeValues();
+        int orphanEntities = storage.totalOrphanEntities();
+        int orphanAttributes = storage.totalOrphanAttributes();
         return rolePlayers + orphanAttributes + orphanEntities;
     }
 

--- a/runner/src/schemaspecific/WebContentGenerator.java
+++ b/runner/src/schemaspecific/WebContentGenerator.java
@@ -468,19 +468,19 @@ public class WebContentGenerator implements SchemaSpecificDataGenerator {
     }
 
     private ScalingUniform scalingUniform(double lowerBoundFraction, double upperBoundFraction) {
-        return new ScalingUniform(random, () -> getGraphSize(), lowerBoundFraction, upperBoundFraction);
+        return new ScalingUniform(random, () -> getGraphScale(), lowerBoundFraction, upperBoundFraction);
     }
 
     private ScalingDiscreteGaussian scalingGaussian(double meanScaleFraction, double stddevScaleFraction) {
-        return new ScalingDiscreteGaussian(random, () -> getGraphSize(), meanScaleFraction, stddevScaleFraction);
+        return new ScalingDiscreteGaussian(random, () -> getGraphScale(), meanScaleFraction, stddevScaleFraction);
     }
 
     private ScalingBoundedZipf scalingZipf(double rangeLimitFraction, double initialExponentForScale40) {
-        return new ScalingBoundedZipf(random, () -> getGraphSize(), rangeLimitFraction, initialExponentForScale40);
+        return new ScalingBoundedZipf(random, () -> getGraphScale(), rangeLimitFraction, initialExponentForScale40);
     }
 
     private ScalingConstant scalingConstant(double constantFraction) {
-        return new ScalingConstant(() -> getGraphSize(), constantFraction);
+        return new ScalingConstant(() -> getGraphScale(), constantFraction);
     }
 
     private FromIdStoragePicker<ConceptId> fromIdStorageConceptIdPicker(String typeLabel) {
@@ -524,14 +524,6 @@ public class WebContentGenerator implements SchemaSpecificDataGenerator {
                         valueProvider
                         )
                 );
-    }
-
-
-    private int getGraphSize() {
-        int rolePlayers = storage.totalRolePlayers();
-        int orphanEntities = storage.totalOrphanEntities();
-        int orphanAttributes = storage.totalOrphanAttributes();
-        return rolePlayers + orphanAttributes + orphanEntities;
     }
 
 
@@ -627,6 +619,11 @@ public class WebContentGenerator implements SchemaSpecificDataGenerator {
         ));
 
 
+    }
+
+
+    public ConceptStore getConceptStore() {
+        return this.storage;
     }
 
 }

--- a/runner/src/schemaspecific/WebContentGenerator.java
+++ b/runner/src/schemaspecific/WebContentGenerator.java
@@ -529,8 +529,8 @@ public class WebContentGenerator implements SchemaSpecificDataGenerator {
 
     private int getGraphSize() {
         int rolePlayers = storage.totalRolePlayers();
-        int orphanEntities = storage.totalOrpanEntities();
-        int orphanAttributes = storage.totalOrphanAttributeValues();
+        int orphanEntities = storage.totalOrphanEntities();
+        int orphanAttributes = storage.totalOrphanAttributes();
         return rolePlayers + orphanAttributes + orphanEntities;
     }
 

--- a/runner/src/schemaspecific/WebContentGenerator.java
+++ b/runner/src/schemaspecific/WebContentGenerator.java
@@ -468,19 +468,19 @@ public class WebContentGenerator implements SchemaSpecificDataGenerator {
     }
 
     private ScalingUniform scalingUniform(double lowerBoundFraction, double upperBoundFraction) {
-        return new ScalingUniform(random, () -> storage.totalEntities(), lowerBoundFraction, upperBoundFraction);
+        return new ScalingUniform(random, () -> getGraphSize(), lowerBoundFraction, upperBoundFraction);
     }
 
     private ScalingDiscreteGaussian scalingGaussian(double meanScaleFraction, double stddevScaleFraction) {
-        return new ScalingDiscreteGaussian(random, () -> storage.totalEntities(), meanScaleFraction, stddevScaleFraction);
+        return new ScalingDiscreteGaussian(random, () -> getGraphSize(), meanScaleFraction, stddevScaleFraction);
     }
 
     private ScalingBoundedZipf scalingZipf(double rangeLimitFraction, double initialExponentForScale40) {
-        return new ScalingBoundedZipf(random, () -> storage.totalEntities(), rangeLimitFraction, initialExponentForScale40);
+        return new ScalingBoundedZipf(random, () -> getGraphSize(), rangeLimitFraction, initialExponentForScale40);
     }
 
     private ScalingConstant scalingConstant(double constantFraction) {
-        return new ScalingConstant(() -> storage.totalEntities(), constantFraction);
+        return new ScalingConstant(() -> getGraphSize(), constantFraction);
     }
 
     private FromIdStoragePicker<ConceptId> fromIdStorageConceptIdPicker(String typeLabel) {
@@ -524,6 +524,14 @@ public class WebContentGenerator implements SchemaSpecificDataGenerator {
                         valueProvider
                         )
                 );
+    }
+
+
+    private int getGraphSize() {
+        int rolePlayers = storage.totalRolePlayers();
+        int orphanEntities = storage.totalOrpanEntities();
+        int orphanAttributes = storage.totalOrphanAttributeValues();
+        return rolePlayers + orphanAttributes + orphanEntities;
     }
 
 

--- a/runner/src/storage/ConceptStore.java
+++ b/runner/src/storage/ConceptStore.java
@@ -30,7 +30,7 @@ public interface ConceptStore {
 
     int totalConceptIds();
     int totalRolePlayers();
-    int totalOrpanEntities();
-    int totalOrphanAttributeValues();
+    int totalOrphanEntities();
+    int totalOrphanAttributes();
     int totalRelationshipsRolePlayersOverlap();
 }

--- a/runner/src/storage/ConceptStore.java
+++ b/runner/src/storage/ConceptStore.java
@@ -19,6 +19,7 @@
 package grakn.benchmark.runner.storage;
 
 import grakn.core.concept.Concept;
+import grakn.core.concept.ConceptId;
 
 /**
  *
@@ -26,7 +27,7 @@ import grakn.core.concept.Concept;
 public interface ConceptStore {
 
     void addConcept(Concept concept);
-    void addRolePlayer(Concept concept);
+    void addRolePlayer(String conceptId);
 
     int totalRolePlayers();
     int totalOrphanEntities();

--- a/runner/src/storage/ConceptStore.java
+++ b/runner/src/storage/ConceptStore.java
@@ -29,6 +29,7 @@ public interface ConceptStore {
     void addConcept(Concept concept);
     void addRolePlayer(String conceptId);
 
+    int totalRelationships();
     int totalRolePlayers();
     int totalOrphanEntities();
     int totalOrphanAttributes();

--- a/runner/src/storage/ConceptStore.java
+++ b/runner/src/storage/ConceptStore.java
@@ -25,11 +25,12 @@ import grakn.core.concept.Concept;
  */
 public interface ConceptStore {
 
-    void add(Concept concept);
+    void addConcept(Concept concept);
+    void addRolePlayer(Concept concept);
 
-    int total();
-
-    int totalEntities();
-    int totalRelationships();
-    int totalAttributes();
+    int totalConceptIds();
+    int totalRolePlayers();
+    int totalOrpanEntities();
+    int totalOrphanAttributeValues();
+    int totalRelationshipsRolePlayersOverlap();
 }

--- a/runner/src/storage/ConceptStore.java
+++ b/runner/src/storage/ConceptStore.java
@@ -28,7 +28,6 @@ public interface ConceptStore {
     void addConcept(Concept concept);
     void addRolePlayer(Concept concept);
 
-    int totalConceptIds();
     int totalRolePlayers();
     int totalOrphanEntities();
     int totalOrphanAttributes();

--- a/runner/src/storage/IgniteConceptIdStore.java
+++ b/runner/src/storage/IgniteConceptIdStore.java
@@ -92,21 +92,21 @@ public class IgniteConceptIdStore implements IdStoreInterface {
             clean(this.allTypeLabels);
             dropTable("roleplayers"); // one special table for tracking role players
         } catch (SQLException e) {
-            LOG.trace(e.toString());
+            LOG.trace(e.getMessage(), e);
         }
 
         // Register JDBC driver.
         try {
             Class.forName("org.apache.ignite.IgniteJdbcThinDriver");
         } catch (ClassNotFoundException e) {
-            LOG.trace(e.toString());
+            LOG.trace(e.getMessage(), e);
         }
 
         // Open JDBC connection.
         try {
             this.conn = DriverManager.getConnection("jdbc:ignite:thin://127.0.0.1/");
         } catch (SQLException e) {
-            LOG.trace(e.toString());
+            LOG.trace(e.getMessage(), e);
         }
 
         // Create database tables.
@@ -182,7 +182,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                     "nothing LONG) " +
                     " WITH \"template=" + cachingMethod + "\"");
         } catch (SQLException e) {
-            LOG.trace(e.toString());
+            LOG.trace(e.getMessage(), e);
         }
     }
 
@@ -199,7 +199,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                     "nothing LONG) " +
                     " WITH \"template=" + cachingMethod + "\"");
         } catch (SQLException e) {
-            LOG.trace(e.toString());
+            LOG.trace(e.getMessage(), e);
         }
     }
 
@@ -266,7 +266,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                     // TODO Doesn't seem like the right way to go
                     // In the case of duplicate primary key, which we want to ignore since I want to keep a unique set of
                     // attribute values in each table
-                    LOG.trace(e.toString());
+                    LOG.trace(e.getMessage(), e);
                 }
             }
 
@@ -281,7 +281,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
 
             } catch (SQLException e) {
                 if (!e.getSQLState().equals("23000")) {
-                    LOG.trace(e.toString());
+                    LOG.trace(e.getMessage(), e);
                 }
             }
         }
@@ -299,7 +299,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
             // attribute values in each table
 
             // this was way too verbose
-            LOG.trace(e.toString());
+            LOG.trace(e.getMessage(), e);
         }
     }
 
@@ -330,10 +330,10 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                     return ConceptId.of(rs.getString(ID_INDEX));
                 }
             } catch (SQLException e) {
-                LOG.trace(e.toString());
+                LOG.trace(e.getMessage(), e);
             }
         } catch (SQLException e) {
-            LOG.trace(e.toString());
+            LOG.trace(e.getMessage(), e);
         }
         return null;
     }
@@ -345,10 +345,10 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                     return rs.getString(ID_INDEX);
                 }
             } catch (SQLException e) {
-                LOG.trace(e.toString());
+                LOG.trace(e.getMessage(), e);
             }
         } catch (SQLException e) {
-            LOG.trace(e.toString());
+            LOG.trace(e.getMessage(), e);
         }
         return null;
 
@@ -361,10 +361,10 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                     return rs.getDouble(ID_INDEX);
                 }
             } catch (SQLException e) {
-                LOG.trace(e.toString());
+                LOG.trace(e.getMessage(), e);
             }
         } catch (SQLException e) {
-            LOG.trace(e.toString());
+            LOG.trace(e.getMessage(), e);
         }
         return null;
     }
@@ -376,10 +376,10 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                     return rs.getLong(ID_INDEX);
                 }
             } catch (SQLException e) {
-                LOG.trace(e.toString());
+                LOG.trace(e.getMessage(), e);
             }
         } catch (SQLException e) {
-            LOG.trace(e.toString());
+            LOG.trace(e.getMessage(), e);
         }
         return null;
     }
@@ -391,10 +391,10 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                     return rs.getBoolean(ID_INDEX);
                 }
             } catch (SQLException e) {
-                LOG.trace(e.toString());
+                LOG.trace(e.getMessage(), e);
             }
         } catch (SQLException e) {
-            LOG.trace(e.toString());
+            LOG.trace(e.getMessage(), e);
         }
         return null;
     }
@@ -406,10 +406,10 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                     return rs.getDate(ID_INDEX);
                 }
             } catch (SQLException e) {
-                LOG.trace(e.toString());
+                LOG.trace(e.getMessage(), e);
             }
         } catch (SQLException e) {
-            LOG.trace(e.toString());
+            LOG.trace(e.getMessage(), e);
         }
         return null;
     }
@@ -433,10 +433,10 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                 }
 
             } catch (SQLException e) {
-                LOG.trace(e.toString());
+                LOG.trace(e.getMessage(), e);
             }
         } catch (SQLException e) {
-            LOG.trace(e.toString());
+            LOG.trace(e.getMessage(), e);
         }
         return 0;
     }
@@ -513,10 +513,10 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                     ids.add(resultSet.getString(ID_INDEX));
                 }
             } catch (SQLException e) {
-                LOG.trace(e.toString());
+                LOG.trace(e.getMessage(), e);
             }
         } catch (SQLException e) {
-            LOG.trace(e.toString());
+            LOG.trace(e.getMessage(), e);
         }
 
         return ids;
@@ -536,7 +536,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
         try (PreparedStatement stmt = conn.prepareStatement("DROP TABLE IF EXISTS " + this.getTableName(tableName))) {
             stmt.executeUpdate();
         } catch (SQLException e) {
-            LOG.trace(e.toString());
+            LOG.trace(e.getMessage(), e);
         }
     }
 }

--- a/runner/src/storage/IgniteConceptIdStore.java
+++ b/runner/src/storage/IgniteConceptIdStore.java
@@ -294,7 +294,9 @@ public class IgniteConceptIdStore implements IdStoreInterface {
             // TODO Doesn't seem like the right way to go
             // In the case of duplicate primary key, which we want to ignore since I want to keep a unique set of
             // attribute values in each table
-            e.printStackTrace();
+
+            // this was way too verbose
+//            e.printStackTrace();
         }
     }
 
@@ -411,11 +413,11 @@ public class IgniteConceptIdStore implements IdStoreInterface {
 
     public int getConceptCount(String typeLabel) {
         String tableName = getTableName(typeLabel);
-        return getCount(tableName);
+        return getCountInTable(tableName);
     }
 
 
-    private int getCount(String tableName) {
+    private int getCountInTable(String tableName) {
         String sql = "SELECT COUNT(1) FROM " + tableName;
 
         try (Statement stmt = conn.createStatement()) {
@@ -437,8 +439,17 @@ public class IgniteConceptIdStore implements IdStoreInterface {
     }
 
     @Override
+    public int totalRelationships() {
+        int total = 0;
+        for (String relationshipType : this.relationshipTypeLabels) {
+            total += getConceptCount(relationshipType);
+        }
+        return total;
+    }
+
+    @Override
     public int totalRolePlayers() {
-        return getCount("roleplayers");
+        return getCountInTable("roleplayers");
     }
 
     /**

--- a/runner/src/storage/IgniteConceptIdStore.java
+++ b/runner/src/storage/IgniteConceptIdStore.java
@@ -438,16 +438,6 @@ public class IgniteConceptIdStore implements IdStoreInterface {
     }
 
     @Override
-    public int totalConceptIds() {
-        int total = 0;
-        for (String typeLabel : this.allTypeLabels) {
-            total += this.getConceptCount(typeLabel);
-        }
-        return total;
-    }
-
-
-    @Override
     public int totalRolePlayers() {
         return getCount("roleplayers");
     }

--- a/runner/src/storage/IgniteConceptIdStore.java
+++ b/runner/src/storage/IgniteConceptIdStore.java
@@ -457,7 +457,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
      * @return
      */
     @Override
-    public int totalOrpanEntities() {
+    public int totalOrphanEntities() {
         Set<String> rolePlayerIds = getIds("roleplayers");
         Set<String> entityIds = new HashSet<>();
         for (String typeLabel: this.entityTypeLabels) {
@@ -473,7 +473,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
      * @return
      */
     @Override
-    public int totalOrphanAttributeValues() {
+    public int totalOrphanAttributes() {
         Set<String> rolePlayerIds = getIds("roleplayers");
         Set<String> attributeIds = new HashSet<>();
         for (String typeLabel: this.attributeTypeLabels.keySet()) {
@@ -503,10 +503,12 @@ public class IgniteConceptIdStore implements IdStoreInterface {
 
     private Set<String> getIds(String tableName) {
         String sql = "SELECT id FROM " + tableName;
+        Set<String> ids = new HashSet<>();
         try (Statement stmt = conn.createStatement()) {
             try (ResultSet resultSet = stmt.executeQuery(sql)) {
-                System.out.println(resultSet);
-
+                while (resultSet.next()) {
+                    ids.add(resultSet.getString(ID_INDEX));
+                }
             } catch (SQLException e) {
                 e.printStackTrace();
             }
@@ -514,7 +516,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
             e.printStackTrace();
         }
 
-        return new HashSet<>();
+        return ids;
     }
 
     /**

--- a/runner/src/storage/IgniteConceptIdStore.java
+++ b/runner/src/storage/IgniteConceptIdStore.java
@@ -284,8 +284,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
         }
     }
 
-    public void addRolePlayer(Concept concept) {
-        String conceptId = concept.asThing().id().toString();
+    public void addRolePlayer(String conceptId) {
         try (PreparedStatement stmt = this.conn.prepareStatement(
                 "INSERT INTO roleplayers (id, ) VALUES (?, )")) {
 

--- a/runner/src/storage/IgniteConceptIdStore.java
+++ b/runner/src/storage/IgniteConceptIdStore.java
@@ -26,6 +26,8 @@ import grakn.core.concept.EntityType;
 import grakn.core.concept.Label;
 import grakn.core.concept.RelationshipType;
 import grakn.core.concept.SchemaConcept;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.Date;
@@ -51,6 +53,7 @@ import static grakn.core.concept.AttributeType.DataType.STRING;
  * Stores identifiers for all concepts in a Grakn
  */
 public class IgniteConceptIdStore implements IdStoreInterface {
+    private static final Logger LOG = LoggerFactory.getLogger(IgniteConceptIdStore.class);
 
     private final HashSet<String> entityTypeLabels;
     private final HashSet<String> relationshipTypeLabels;
@@ -89,21 +92,21 @@ public class IgniteConceptIdStore implements IdStoreInterface {
             clean(this.allTypeLabels);
             dropTable("roleplayers"); // one special table for tracking role players
         } catch (SQLException e) {
-            e.printStackTrace();
+            LOG.trace(e.toString());
         }
 
         // Register JDBC driver.
         try {
             Class.forName("org.apache.ignite.IgniteJdbcThinDriver");
         } catch (ClassNotFoundException e) {
-            e.printStackTrace();
+            LOG.trace(e.toString());
         }
 
         // Open JDBC connection.
         try {
             this.conn = DriverManager.getConnection("jdbc:ignite:thin://127.0.0.1/");
         } catch (SQLException e) {
-            e.printStackTrace();
+            LOG.trace(e.toString());
         }
 
         // Create database tables.
@@ -179,7 +182,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                     "nothing LONG) " +
                     " WITH \"template=" + cachingMethod + "\"");
         } catch (SQLException e) {
-            e.printStackTrace();
+            LOG.trace(e.toString());
         }
     }
 
@@ -196,7 +199,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                     "nothing LONG) " +
                     " WITH \"template=" + cachingMethod + "\"");
         } catch (SQLException e) {
-            e.printStackTrace();
+            LOG.trace(e.toString());
         }
     }
 
@@ -263,7 +266,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                     // TODO Doesn't seem like the right way to go
                     // In the case of duplicate primary key, which we want to ignore since I want to keep a unique set of
                     // attribute values in each table
-                    e.printStackTrace();
+                    LOG.trace(e.toString());
                 }
             }
 
@@ -278,7 +281,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
 
             } catch (SQLException e) {
                 if (!e.getSQLState().equals("23000")) {
-                    e.printStackTrace();
+                    LOG.trace(e.toString());
                 }
             }
         }
@@ -296,7 +299,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
             // attribute values in each table
 
             // this was way too verbose
-//            e.printStackTrace();
+            LOG.trace(e.toString());
         }
     }
 
@@ -327,10 +330,10 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                     return ConceptId.of(rs.getString(ID_INDEX));
                 }
             } catch (SQLException e) {
-                e.printStackTrace();
+                LOG.trace(e.toString());
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            LOG.trace(e.toString());
         }
         return null;
     }
@@ -342,10 +345,10 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                     return rs.getString(ID_INDEX);
                 }
             } catch (SQLException e) {
-                e.printStackTrace();
+                LOG.trace(e.toString());
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            LOG.trace(e.toString());
         }
         return null;
 
@@ -358,10 +361,10 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                     return rs.getDouble(ID_INDEX);
                 }
             } catch (SQLException e) {
-                e.printStackTrace();
+                LOG.trace(e.toString());
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            LOG.trace(e.toString());
         }
         return null;
     }
@@ -373,10 +376,10 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                     return rs.getLong(ID_INDEX);
                 }
             } catch (SQLException e) {
-                e.printStackTrace();
+                LOG.trace(e.toString());
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            LOG.trace(e.toString());
         }
         return null;
     }
@@ -388,10 +391,10 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                     return rs.getBoolean(ID_INDEX);
                 }
             } catch (SQLException e) {
-                e.printStackTrace();
+                LOG.trace(e.toString());
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            LOG.trace(e.toString());
         }
         return null;
     }
@@ -403,10 +406,10 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                     return rs.getDate(ID_INDEX);
                 }
             } catch (SQLException e) {
-                e.printStackTrace();
+                LOG.trace(e.toString());
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            LOG.trace(e.toString());
         }
         return null;
     }
@@ -430,10 +433,10 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                 }
 
             } catch (SQLException e) {
-                e.printStackTrace();
+                LOG.trace(e.toString());
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            LOG.trace(e.toString());
         }
         return 0;
     }
@@ -510,10 +513,10 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                     ids.add(resultSet.getString(ID_INDEX));
                 }
             } catch (SQLException e) {
-                e.printStackTrace();
+                LOG.trace(e.toString());
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            LOG.trace(e.toString());
         }
 
         return ids;
@@ -533,7 +536,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
         try (PreparedStatement stmt = conn.prepareStatement("DROP TABLE IF EXISTS " + this.getTableName(tableName))) {
             stmt.executeUpdate();
         } catch (SQLException e) {
-            e.printStackTrace();
+            LOG.trace(e.toString());
         }
     }
 }

--- a/runner/src/storage/InsertionAnalysis.java
+++ b/runner/src/storage/InsertionAnalysis.java
@@ -79,11 +79,11 @@ public class InsertionAnalysis {
     }
 
     /**
-     * Given the query and answers, return the IDs of the concepts that filled ROLES in any relationships
+     * Given the query, return the IDs of the concepts that filled ROLES in any relationships
      * that were added in the given insert query. Returns empty set if none/no relationships added
      * @return
      */
-    public static HashSet<Concept> getRolePlayers(InsertQuery query, List<ConceptMap> answers) {
+    public static HashSet<Concept> getRolePlayers(InsertQuery query) {
         // TODO
         return null;
     }

--- a/runner/src/storage/InsertionAnalysis.java
+++ b/runner/src/storage/InsertionAnalysis.java
@@ -78,6 +78,16 @@ public class InsertionAnalysis {
         return resultConcepts;
     }
 
+    /**
+     * Given the query and answers, return the IDs of the concepts that filled ROLES in any relationships
+     * that were added in the given insert query. Returns empty set if none/no relationships added
+     * @return
+     */
+    public static HashSet<Concept> getRolePlayers(InsertQuery query, List<ConceptMap> answers) {
+        // TODO
+        return null;
+    }
+
     private static HashSet<Var> getVars(Iterator<VarPatternAdmin> varPatternAdminIterator) {
         HashSet<Var> vars = new HashSet<>();
         while (varPatternAdminIterator.hasNext()) {

--- a/runner/src/storage/InsertionAnalysis.java
+++ b/runner/src/storage/InsertionAnalysis.java
@@ -18,10 +18,8 @@
 
 package grakn.benchmark.runner.storage;
 
-import com.sun.javafx.beans.IDProperty;
 import grakn.core.concept.Concept;
 import grakn.core.concept.ConceptId;
-import grakn.core.graql.Graql;
 import grakn.core.graql.InsertQuery;
 import grakn.core.graql.Match;
 import grakn.core.graql.Var;
@@ -90,18 +88,19 @@ public class InsertionAnalysis {
         // find variables and their associated IDs
         HashMap<Var, ConceptId> varIds = new HashMap<>();
         Set<Var> rolePlayerVars = new HashSet<>();
+        if (query.admin().match() != null) {
+            for (VarPatternAdmin patternAdmin : query.admin().match().admin().getPattern().varPatterns()) {
+                Var var = patternAdmin.var();
+                Optional<IdProperty> idProperty = patternAdmin.getProperty(IdProperty.class);
+                if (idProperty.isPresent()) {
+                    varIds.put(var, idProperty.get().id());
+                }
+            }
+        }
         for (VarPatternAdmin patternAdmin : query.admin().varPatterns()) {
-            Var var = patternAdmin.var();
-
             Optional<RelationshipProperty> relationshipProperty = patternAdmin.getProperty(RelationshipProperty.class);
             if (relationshipProperty.isPresent()) {
                 rolePlayerVars.addAll(relationshipProperty.get().innerVarPatterns().map(vpa -> vpa.var()).collect(Collectors.toSet()));
-                continue;
-            }
-
-            Optional<IdProperty> idProperty = patternAdmin.getProperty(IdProperty.class);
-            if (idProperty.isPresent()) {
-                varIds.put(var, idProperty.get().id());
             }
         }
 

--- a/runner/test/storage/IgniteConceptIdStoreTest.java
+++ b/runner/test/storage/IgniteConceptIdStoreTest.java
@@ -235,7 +235,7 @@ public class IgniteConceptIdStoreTest {
         }
 
         int roleplayerCount = this.store.totalRolePlayers();
-        assertEquals(7, roleplayerCount);
+        assertEquals(9, roleplayerCount);
     }
 
     @Test

--- a/runner/test/storage/IgniteConceptIdStoreTest.java
+++ b/runner/test/storage/IgniteConceptIdStoreTest.java
@@ -231,7 +231,7 @@ public class IgniteConceptIdStoreTest {
         this.store = new IgniteConceptIdStore(entityTypes, relationshipTypes, attributeTypes);
 
         for (Concept conceptMock : this.conceptMocks) {
-            this.store.addRolePlayer(conceptMock);
+            this.store.addRolePlayer(conceptMock.asThing().id().toString());
         }
 
         int roleplayerCount = this.store.totalRolePlayers();
@@ -250,11 +250,11 @@ public class IgniteConceptIdStoreTest {
         // add 6 of 7 entities as role players too
         for (int i = 0 ; i < 6; i++) {
             Concept conceptMock = this.conceptMocks.get(i);
-            this.store.addRolePlayer(conceptMock);
+            this.store.addRolePlayer(conceptMock.asThing().id().toString());
         }
 
         int orphanEntities = this.store.totalOrphanEntities();
-        assertEquals(orphanEntities, 1);
+        assertEquals(1, orphanEntities);
     }
 
     @Test
@@ -269,11 +269,11 @@ public class IgniteConceptIdStoreTest {
         // ad all but the attribute and relationship
         for (int i = 0 ; i < conceptMocks.size()-2; i++) {
             Concept conceptMock = this.conceptMocks.get(i);
-            this.store.addRolePlayer(conceptMock);
+            this.store.addRolePlayer(conceptMock.asThing().id().toString());
         }
 
         int orphanAttributes = this.store.totalOrphanAttributes();
-        assertEquals(orphanAttributes, 1);
+        assertEquals(1, orphanAttributes);
     }
 
     @Test
@@ -288,11 +288,11 @@ public class IgniteConceptIdStoreTest {
         // add all but the relationship (last element)
         for (int i = 0 ; i < conceptMocks.size()-1; i++) {
             Concept conceptMock = this.conceptMocks.get(i);
-            this.store.addRolePlayer(conceptMock);
+            this.store.addRolePlayer(conceptMock.asThing().id().toString());
         }
 
         int relationshipDoubleCounts = this.store.totalRelationshipsRolePlayersOverlap();
-        assertEquals(relationshipDoubleCounts, 0);
+        assertEquals(0, relationshipDoubleCounts);
     }
 
     @Test
@@ -307,10 +307,10 @@ public class IgniteConceptIdStoreTest {
         // add all as role players
         for (int i = 0 ; i < conceptMocks.size(); i++) {
             Concept conceptMock = this.conceptMocks.get(i);
-            this.store.addRolePlayer(conceptMock);
+            this.store.addRolePlayer(conceptMock.asThing().id().toString());
         }
 
         int relationshipDoubleCounts = this.store.totalRelationshipsRolePlayersOverlap();
-        assertEquals(relationshipDoubleCounts, 1);
+        assertEquals(1, relationshipDoubleCounts);
     }
 }

--- a/runner/test/storage/IgniteConceptIdStoreTest.java
+++ b/runner/test/storage/IgniteConceptIdStoreTest.java
@@ -26,7 +26,12 @@ import grakn.core.concept.Label;
 import grakn.core.concept.RelationshipType;
 import grakn.core.concept.Thing;
 import grakn.core.concept.Type;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.Ignition;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.sql.Connection;
@@ -55,6 +60,16 @@ public class IgniteConceptIdStoreTest {
     private String typeLabel;
 
     HashSet<EntityType> entityTypes;
+
+    @BeforeClass
+    public static void initIgniteServer() throws IgniteException {
+        Ignition.start();
+    }
+
+    @AfterClass
+    public static void stopIgniteServer() {
+        Ignition.stop(false);
+    }
 
     @Before
     public void setUp() {
@@ -113,7 +128,7 @@ public class IgniteConceptIdStoreTest {
 
         // Add all of the elements
         for (Concept conceptMock : this.conceptMocks) {
-            this.store.add(conceptMock);
+            this.store.addConcept(conceptMock);
         }
 
         int counter = 0;
@@ -136,7 +151,7 @@ public class IgniteConceptIdStoreTest {
         this.store = new IgniteConceptIdStore(entityTypes, new HashSet<RelationshipType>(), new HashSet<AttributeType>());
 
         int index = 0;
-        this.store.add(this.conceptMocks.get(index));
+        this.store.addConcept(this.conceptMocks.get(index));
         ConceptId personConceptId = this.store.getConceptId(this.typeLabel, index);
         System.out.println("Found id: " + personConceptId.toString());
         assertEquals(personConceptId, this.conceptIds.get(index));
@@ -150,7 +165,7 @@ public class IgniteConceptIdStoreTest {
         // Add all of the elements
 
         for (Concept conceptMock : this.conceptMocks) {
-            this.store.add(conceptMock);
+            this.store.addConcept(conceptMock);
         }
 
         ConceptId personConceptId = this.store.getConceptId(this.typeLabel, index);
@@ -163,10 +178,23 @@ public class IgniteConceptIdStoreTest {
         this.store = new IgniteConceptIdStore(entityTypes, new HashSet<RelationshipType>(), new HashSet<AttributeType>());
 
         for (Concept conceptMock : this.conceptMocks) {
-            this.store.add(conceptMock);
+            this.store.addConcept(conceptMock);
         }
 
         int count = this.store.getConceptCount(this.typeLabel);
         assertEquals(7, count);
+    }
+
+    @Test
+    public void whenRoleplayerIsAdded_idCanBeRetrieved() throws SQLException {
+        this.store = new IgniteConceptIdStore(entityTypes, new HashSet<RelationshipType>(), new HashSet<AttributeType>());
+
+        Concept concept = conceptMocks.get(0);
+        for (Concept conceptMock : this.conceptMocks) {
+            this.store.addRolePlayer(conceptMock);
+        }
+
+        int roleplayerCount = this.store.totalRolePlayers();
+        assertEquals(7, roleplayerCount);
     }
 }

--- a/runner/test/storage/IgniteConceptIdStoreTest.java
+++ b/runner/test/storage/IgniteConceptIdStoreTest.java
@@ -161,12 +161,13 @@ public class IgniteConceptIdStoreTest {
         when(relThingMock.type()).thenReturn(relConceptTypeMock); // Concept Type
         when(relConceptTypeMock.label()).thenReturn(Label.of("friend")); // Type label
 
+
+        // create new ignite store
+        this.store = new IgniteConceptIdStore(entityTypes, relationshipTypes, attributeTypes);
     }
 
     @Test
     public void whenConceptIdsAreAdded_conceptIdsAreInTheDB() throws SQLException {
-        this.store = new IgniteConceptIdStore(entityTypes, relationshipTypes, attributeTypes);
-
         // Add all of the elements
         for (Concept conceptMock : this.conceptMocks) {
             this.store.addConcept(conceptMock);
@@ -189,8 +190,6 @@ public class IgniteConceptIdStoreTest {
 
     @Test
     public void whenConceptIsAdded_conceptIdCanBeRetrieved() throws SQLException {
-        this.store = new IgniteConceptIdStore(entityTypes, relationshipTypes, attributeTypes);
-
         int index = 0;
         this.store.addConcept(this.conceptMocks.get(index));
         ConceptId personConceptId = this.store.getConceptId(this.entityTypeLabel, index);
@@ -200,8 +199,6 @@ public class IgniteConceptIdStoreTest {
 
     @Test
     public void whenGettingIdWithOffset_correctIdIsReturned() throws SQLException {
-        this.store = new IgniteConceptIdStore(entityTypes, relationshipTypes, attributeTypes);
-
         int index = 4;
         // Add all of the elements
 
@@ -216,8 +213,6 @@ public class IgniteConceptIdStoreTest {
 
     @Test
     public void whenCountingTypeInstances_resultIsCorrect() throws SQLException, ClassNotFoundException {
-        this.store = new IgniteConceptIdStore(entityTypes, relationshipTypes, attributeTypes);
-
         for (Concept conceptMock : this.conceptMocks) {
             this.store.addConcept(conceptMock);
         }
@@ -228,8 +223,6 @@ public class IgniteConceptIdStoreTest {
 
     @Test
     public void whenRolePlayerIsAdded_countIsCorrect() {
-        this.store = new IgniteConceptIdStore(entityTypes, relationshipTypes, attributeTypes);
-
         for (Concept conceptMock : this.conceptMocks) {
             this.store.addRolePlayer(conceptMock.asThing().id().toString());
         }
@@ -240,8 +233,6 @@ public class IgniteConceptIdStoreTest {
 
     @Test
     public void whenAllButOnePlayingRole_orphanEntitiesCorrect() {
-        this.store = new IgniteConceptIdStore(entityTypes, relationshipTypes, attributeTypes);
-
         // add all concepts to store
         for (Concept conceptMock : this.conceptMocks) {
             this.store.addConcept(conceptMock);
@@ -259,8 +250,6 @@ public class IgniteConceptIdStoreTest {
 
     @Test
     public void whenAllButOnePlayingRole_orphanAttributesCorrect() {
-        this.store = new IgniteConceptIdStore(entityTypes, relationshipTypes, attributeTypes);
-
         // add all concepts to store
         for (Concept conceptMock : this.conceptMocks) {
             this.store.addConcept(conceptMock);
@@ -278,8 +267,6 @@ public class IgniteConceptIdStoreTest {
 
     @Test
     public void whenRelationshipsDoNotOverlap_overlapEmpty() {
-        this.store = new IgniteConceptIdStore(entityTypes, relationshipTypes, attributeTypes);
-
         // add all concepts to store
         for (Concept conceptMock : this.conceptMocks) {
             this.store.addConcept(conceptMock);
@@ -296,9 +283,7 @@ public class IgniteConceptIdStoreTest {
     }
 
     @Test
-    public void whenRelationshipsDoNotOverlap_overlapOne() {
-        this.store = new IgniteConceptIdStore(entityTypes, relationshipTypes, attributeTypes);
-
+    public void whenRelationshipPlaysRole_overlapOne() {
         // add all concepts to store
         for (Concept conceptMock : this.conceptMocks) {
             this.store.addConcept(conceptMock);

--- a/runner/test/storage/InsertionAnalysisTest.java
+++ b/runner/test/storage/InsertionAnalysisTest.java
@@ -205,7 +205,6 @@ public class InsertionAnalysisTest {
 
     @Test
     public void whenInsertRelationship_IdentifyRolePlayers() {
-//        String query = "insert $x id V123; $y id V234; ($x, $y) isa friendship;";
         VarPattern x = var("x").asUserDefined().id(ConceptId.of("V123"));
         VarPattern y = var("y").asUserDefined().id(ConceptId.of("V234"));
         InsertQuery insertQuery = Graql.insert(x, y, var("r").rel(x).rel(y).isa("friendship"));

--- a/runner/test/storage/InsertionAnalysisTest.java
+++ b/runner/test/storage/InsertionAnalysisTest.java
@@ -24,15 +24,15 @@ import grakn.core.concept.Thing;
 import grakn.core.graql.Graql;
 import grakn.core.graql.InsertQuery;
 import grakn.core.graql.Var;
+import grakn.core.graql.VarPattern;
 import grakn.core.graql.answer.ConceptMap;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
+import java.util.*;
 
+import static grakn.core.graql.Graql.var;
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -63,7 +63,7 @@ public class InsertionAnalysisTest {
     @Test
     public void whenEntityInserted_IdentifyEntityWasInserted() {
 
-        Var x = Graql.var("x");
+        Var x = var("x");
         InsertQuery query = Graql.insert(x.isa("company"));
 
         HashMap<Var, String> vars = new HashMap<>();
@@ -84,10 +84,10 @@ public class InsertionAnalysisTest {
         String yId = "Vy";
         String zId = "Vz";
 
-        Var r = Graql.var("r");
-        Var x = Graql.var("x").asUserDefined();
-        Var y = Graql.var("y").asUserDefined();
-        Var z = Graql.var("z").asUserDefined();
+        Var r = var("r");
+        Var x = var("x").asUserDefined();
+        Var y = var("y").asUserDefined();
+        Var z = var("z").asUserDefined();
 
         HashMap<Var, String> vars = new HashMap<>();
         vars.put(r, rId);
@@ -121,10 +121,10 @@ public class InsertionAnalysisTest {
         String yId = "Vy";
         String zId = "Vz";
 
-        Var r = Graql.var("r");
-        Var x = Graql.var("x").asUserDefined();
-        Var y = Graql.var("y").asUserDefined();
-        Var z = Graql.var("z").asUserDefined();
+        Var r = var("r");
+        Var x = var("x").asUserDefined();
+        Var y = var("y").asUserDefined();
+        Var z = var("z").asUserDefined();
 
         HashMap<Var, String> vars = new HashMap<>();
         vars.put(r, rId);
@@ -158,8 +158,8 @@ public class InsertionAnalysisTest {
 
         String cAttr = "c-name";
 
-        Var x = Graql.var("x").asUserDefined();
-        Var y = Graql.var("y").asUserDefined();
+        Var x = var("x").asUserDefined();
+        Var y = var("y").asUserDefined();
 
         HashMap<Var, String> vars = new HashMap<>();
         vars.put(x, xId);
@@ -185,8 +185,8 @@ public class InsertionAnalysisTest {
 
         String cAttr = "c-name";
 
-        Var x = Graql.var("x").asUserDefined();
-        Var y = Graql.var("y").asUserDefined();
+        Var x = var("x").asUserDefined();
+        Var y = var("y").asUserDefined();
 
         HashMap<Var, String> vars = new HashMap<>();
         vars.put(x, xId);
@@ -205,11 +205,22 @@ public class InsertionAnalysisTest {
 
     @Test
     public void whenInsertRelationship_IdentifyRolePlayers() {
-        // TODO
+//        String query = "insert $x id V123; $y id V234; ($x, $y) isa friendship;";
+        VarPattern x = var("x").asUserDefined().id(ConceptId.of("V123"));
+        VarPattern y = var("y").asUserDefined().id(ConceptId.of("V234"));
+        InsertQuery insertQuery = Graql.insert(x, y, var("r").rel(x).rel(y).isa("friendship"));
+
+        Set<ConceptId> rolePlayerIds = InsertionAnalysis.getRolePlayers(insertQuery);
+        assertTrue(rolePlayerIds.contains(ConceptId.of("V123")));
+        assertTrue(rolePlayerIds.contains(ConceptId.of("V234")));
     }
 
     @Test
     public void whenInsertNonRelationship_ReturnEmptySet() {
-        // TODO
+        VarPattern x = var("x").asUserDefined();
+        VarPattern y = var("y").asUserDefined();
+        InsertQuery insert = Graql.insert(x.isa("company").has("name", y).id(ConceptId.of("V123")), y.val("john"));
+        Set<ConceptId> rolePlayerIds = InsertionAnalysis.getRolePlayers(insert);
+        assertEquals(0, rolePlayerIds.size());
     }
 }

--- a/runner/test/storage/InsertionAnalysisTest.java
+++ b/runner/test/storage/InsertionAnalysisTest.java
@@ -202,4 +202,14 @@ public class InsertionAnalysisTest {
         assertEquals(1, insertedConcepts.size());
         assertEquals(yId, insertedConcepts.iterator().next().asThing().id().toString());
     }
+
+    @Test
+    public void whenInsertRelationship_IdentifyRolePlayers() {
+        // TODO
+    }
+
+    @Test
+    public void whenInsertNonRelationship_ReturnEmptySet() {
+        // TODO
+    }
 }


### PR DESCRIPTION
Primary goal:
Implements redefinition as graph scale. Previously, in Data Generator, the total number of entities, relationships, and (unique) attribute instances were counted to create the graph size. This was used to decide when to stop generating, and when to profile the graphs that have been generated. 

New definition: want graph scale to be roughly equivalent to "vertices" in a normal graph. To make this compatible with our typed, attributed hypergraph structure with role players (referred to "extended hypergraph"), we use the following new definition of "vertices" and "edges" (let's call it "edge-centric" definition, rather than a "vertex-centric" or "entity-centric" approach): 
Define "edges" as the number of relationship instances.
Define "vertices" as the number of role players + orphan entities + orphan attributes. Intuitively, this captures all _endpoints_ of relationships, plus disconnected entities and attributes. This new definition succinctly quantifies anything acting as an endpoint, be it entity, relationship or attribute.

Caveats: 
* double counts some relationships that are also role players
* promotes attributes and relationships to contribute to graph scale
  * not bad, just different from counting only entities or everything before
Consequences:
* can track quality of data generator by looking at number of orphaned entities and attributes
* track double counting between relationships (edges) and roles (vertices) to see how common it is for relationships to play roles
* Reduces to intuitive definition of "scale" being number of vertices when (hyper)-edges only connected entities together (ie. only entities play roles)

