### PR TITLE
Fix failing `metric` tests

### DIFF
--- a/metric/test/AssortativityIT.java
+++ b/metric/test/AssortativityIT.java
@@ -44,6 +44,7 @@ public class AssortativityIT {
 
         // define basic schema
         String keyspaceName = "assortativity_it";
+        client.keyspaces().delete(Keyspace.of(keyspaceName));
         Grakn.Session session = client.session(Keyspace.of(keyspaceName));
         Grakn.Transaction tx = session.transaction(GraknTxType.WRITE);
         List<?> answer = tx.graql().parse("define vertex sub entity, plays endpt; edge sub relationship, relates endpt;").execute();
@@ -71,6 +72,7 @@ public class AssortativityIT {
         double computedAssortativity = Assortativity.computeAssortativity(Assortativity.jointDegreeOccurrence(graphProperties));
         double correctAssortativity = -0.38888888888888995;
         double allowedDeviation = 0.000001;
+        session.close();
         client.keyspaces().delete(Keyspace.of(keyspaceName));
         assertEquals(correctAssortativity, computedAssortativity, allowedDeviation);
     }
@@ -82,6 +84,7 @@ public class AssortativityIT {
 
         // define basic schema
         String keyspaceName = "assortativity_it";
+        client.keyspaces().delete(Keyspace.of(keyspaceName));
         Grakn.Session session = client.session(Keyspace.of(keyspaceName));
         Grakn.Transaction tx = session.transaction(GraknTxType.WRITE);
         List<?> answer = tx.graql().parse("define vertex sub entity, plays endpt; edge sub relationship, relates endpt;").execute();
@@ -111,6 +114,7 @@ public class AssortativityIT {
         double computedAssortativity = Assortativity.computeAssortativity(Assortativity.jointDegreeOccurrence(graphProperties));
         double correctAssortativity = -0.2767857142857146;
         double allowedDeviation = 0.000001;
+        session.close();
         client.keyspaces().delete(Keyspace.of(keyspaceName));
         assertEquals(correctAssortativity, computedAssortativity, allowedDeviation);
     }

--- a/metric/test/AssortativityIT.java
+++ b/metric/test/AssortativityIT.java
@@ -72,8 +72,8 @@ public class AssortativityIT {
         double computedAssortativity = Assortativity.computeAssortativity(Assortativity.jointDegreeOccurrence(graphProperties));
         double correctAssortativity = -0.38888888888888995;
         double allowedDeviation = 0.000001;
-        session.close();
         client.keyspaces().delete(Keyspace.of(keyspaceName));
+        session.close();
         assertEquals(correctAssortativity, computedAssortativity, allowedDeviation);
     }
 
@@ -114,8 +114,8 @@ public class AssortativityIT {
         double computedAssortativity = Assortativity.computeAssortativity(Assortativity.jointDegreeOccurrence(graphProperties));
         double correctAssortativity = -0.2767857142857146;
         double allowedDeviation = 0.000001;
-        session.close();
         client.keyspaces().delete(Keyspace.of(keyspaceName));
+        session.close();
         assertEquals(correctAssortativity, computedAssortativity, allowedDeviation);
     }
 }

--- a/metric/test/DegreeDistributionIT.java
+++ b/metric/test/DegreeDistributionIT.java
@@ -53,6 +53,7 @@ public class DegreeDistributionIT {
 
         // define basic schema
         String keyspaceName = "binary_graph_degree_dist_it";
+        client.keyspaces().delete(Keyspace.of(keyspaceName));
         Grakn.Session session = client.session(Keyspace.of(keyspaceName));
         Grakn.Transaction tx = session.transaction(GraknTxType.WRITE);
         List<?> answer = tx.graql().parse("define vertex sub entity, plays endpt; edge sub relationship, relates endpt;").execute();
@@ -81,9 +82,9 @@ public class DegreeDistributionIT {
         double[] percentiles = new double[]{0, 20, 50, 70, 100};
         long[] discreteDegreeDistribution = DegreeDistribution.discreteDistribution(graphProperties, percentiles);
         long[] correctDegreeDistribution = new long[]{1, 2, 2, 2, 3};
-        assertArrayEquals(correctDegreeDistribution, discreteDegreeDistribution);
-
+        session.close();
         client.keyspaces().delete(Keyspace.of(keyspaceName));
+        assertArrayEquals(correctDegreeDistribution, discreteDegreeDistribution);
     }
 
 
@@ -93,6 +94,7 @@ public class DegreeDistributionIT {
 
         // define basic schema
         String keyspaceName = "binary_graph_degree_dist_it";
+        client.keyspaces().delete(Keyspace.of(keyspaceName));
         Grakn.Session session = client.session(Keyspace.of(keyspaceName));
         Grakn.Transaction tx = session.transaction(GraknTxType.WRITE);
         List<?> answer = tx.graql().parse("define vertex sub entity, plays endpt; edge sub relationship, relates endpt;").execute();
@@ -123,8 +125,8 @@ public class DegreeDistributionIT {
         double[] percentiles = new double[]{0, 20, 50, 70, 100};
         long[] discreteDegreeDistribution = DegreeDistribution.discreteDistribution(graphProperties, percentiles);
         long[] correctDegreeDistribution = new long[]{1, 2, 2, 3, 4};
-        assertArrayEquals(correctDegreeDistribution, discreteDegreeDistribution);
-
+        session.close();
         client.keyspaces().delete(Keyspace.of(keyspaceName));
+        assertArrayEquals(correctDegreeDistribution, discreteDegreeDistribution);
     }
 }

--- a/metric/test/DegreeDistributionIT.java
+++ b/metric/test/DegreeDistributionIT.java
@@ -82,8 +82,8 @@ public class DegreeDistributionIT {
         double[] percentiles = new double[]{0, 20, 50, 70, 100};
         long[] discreteDegreeDistribution = DegreeDistribution.discreteDistribution(graphProperties, percentiles);
         long[] correctDegreeDistribution = new long[]{1, 2, 2, 2, 3};
-        session.close();
         client.keyspaces().delete(Keyspace.of(keyspaceName));
+        session.close();
         assertArrayEquals(correctDegreeDistribution, discreteDegreeDistribution);
     }
 
@@ -125,8 +125,8 @@ public class DegreeDistributionIT {
         double[] percentiles = new double[]{0, 20, 50, 70, 100};
         long[] discreteDegreeDistribution = DegreeDistribution.discreteDistribution(graphProperties, percentiles);
         long[] correctDegreeDistribution = new long[]{1, 2, 2, 3, 4};
-        session.close();
         client.keyspaces().delete(Keyspace.of(keyspaceName));
+        session.close();
         assertArrayEquals(correctDegreeDistribution, discreteDegreeDistribution);
     }
 }

--- a/metric/test/GlobalTransitivityIT.java
+++ b/metric/test/GlobalTransitivityIT.java
@@ -78,8 +78,8 @@ public class GlobalTransitivityIT {
         double computedTransitivity = GlobalTransitivity.computeTransitivity(graphProperties);
         double correctTransitivity = 0.25;
         double allowedDeviationFraction = 0.0000001;
-        session.close();
         client.keyspaces().delete(Keyspace.of(keyspaceName));
+        session.close();
         assertEquals(correctTransitivity, computedTransitivity, allowedDeviationFraction * correctTransitivity);
     }
 
@@ -120,8 +120,8 @@ public class GlobalTransitivityIT {
         double computedTransitivity = GlobalTransitivity.computeTransitivity(graphProperties);
         double correctTransitivity = 0.25;
         double allowedDeviationFraction = 0.0000001;
-        session.close();
         client.keyspaces().delete(Keyspace.of(keyspaceName));
+        session.close();
         assertEquals(correctTransitivity, computedTransitivity, allowedDeviationFraction * correctTransitivity);
     }
 

--- a/metric/test/GlobalTransitivityIT.java
+++ b/metric/test/GlobalTransitivityIT.java
@@ -50,6 +50,7 @@ public class GlobalTransitivityIT {
 
         // define basic schema
         String keyspaceName = "transitivity_it";
+        client.keyspaces().delete(Keyspace.of(keyspaceName));
         Grakn.Session session = client.session(Keyspace.of(keyspaceName));
         Grakn.Transaction tx = session.transaction(GraknTxType.WRITE);
         List<?> answer = tx.graql().parse("define vertex sub entity, plays endpt; edge sub relationship, relates endpt;").execute();
@@ -77,6 +78,7 @@ public class GlobalTransitivityIT {
         double computedTransitivity = GlobalTransitivity.computeTransitivity(graphProperties);
         double correctTransitivity = 0.25;
         double allowedDeviationFraction = 0.0000001;
+        session.close();
         client.keyspaces().delete(Keyspace.of(keyspaceName));
         assertEquals(correctTransitivity, computedTransitivity, allowedDeviationFraction * correctTransitivity);
     }
@@ -88,6 +90,7 @@ public class GlobalTransitivityIT {
 
         // define basic schema
         String keyspaceName = "transitivity_it";
+        client.keyspaces().delete(Keyspace.of(keyspaceName));
         Grakn.Session session = client.session(Keyspace.of(keyspaceName));
         Grakn.Transaction tx = session.transaction(GraknTxType.WRITE);
         List<?> answer = tx.graql().parse("define vertex sub entity, plays endpt; edge sub relationship, relates endpt;").execute();
@@ -117,6 +120,7 @@ public class GlobalTransitivityIT {
         double computedTransitivity = GlobalTransitivity.computeTransitivity(graphProperties);
         double correctTransitivity = 0.25;
         double allowedDeviationFraction = 0.0000001;
+        session.close();
         client.keyspaces().delete(Keyspace.of(keyspaceName));
         assertEquals(correctTransitivity, computedTransitivity, allowedDeviationFraction * correctTransitivity);
     }

--- a/metric/test/GlobalTransitivityTest.java
+++ b/metric/test/GlobalTransitivityTest.java
@@ -120,6 +120,8 @@ public class GlobalTransitivityTest {
         when(mockProperties.neighbors("9")).thenReturn(new HashSet<>(Arrays.asList("8", "10")));
         when(mockProperties.neighbors("10")).thenReturn(new HashSet<>(Arrays.asList("8", "9")));
 
+        when(mockProperties.copy()).thenReturn(mockProperties);
+
         double transitivity = GlobalTransitivity.computeTransitivity(mockProperties);
 
 //        ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);


### PR DESCRIPTION
Fixes
* failing tests where keyspaces were deleted after the assertion, so never cleared, leading to next round of failed tests
* fix failing test where calling `copy()` on a mock of a GraphProperties would fail due to not being implemented.