### PR TITLE
Fix out of order init for DataGenerator, test for existing keyspaces

### DIFF
--- a/runner/BUILD
+++ b/runner/BUILD
@@ -22,8 +22,9 @@ java_binary(
     name = "benchmark-runner-binary",
     main_class = "grakn.benchmark.runner.GraknBenchmark",
     runtime_deps = ["//runner:benchmark-runner"],
-    visibility = ["//visibility:public"]
- )
+    visibility = ["//visibility:public"],
+    classpath_resources = ["//runner:src/logback.xml"]
+)
 
 java_library(
     name = "benchmark-runner",
@@ -57,6 +58,7 @@ java_library(
         "//dependencies/maven/artifacts/io/grpc:grpc-netty-shaded"
     ],
     visibility = ["//visibility:public"]
+
 )
 
 filegroup(

--- a/runner/src/GraknBenchmark.java
+++ b/runner/src/GraknBenchmark.java
@@ -20,6 +20,7 @@ package grakn.benchmark.runner;
 
 import grakn.benchmark.runner.executor.QueryProfiler;
 import grakn.benchmark.runner.generator.DataGenerator;
+import grakn.benchmark.runner.storage.SchemaManager;
 import grakn.benchmark.runner.util.BenchmarkArguments;
 import grakn.benchmark.runner.util.BenchmarkConfiguration;
 import grakn.benchmark.runner.util.ElasticSearchManager;
@@ -94,6 +95,7 @@ public class GraknBenchmark {
     public void start() {
         Grakn client = new Grakn(new SimpleURI(config.uri()));
         Grakn.Session session = client.session(config.getKeyspace());
+        SchemaManager.verifyEmptyKeyspace(session);
 
         QueryProfiler queryProfiler = new QueryProfiler(session, executionName, config.getQueries());
         int repetitionsPerQuery = config.numQueryRepetitions();
@@ -104,7 +106,6 @@ public class GraknBenchmark {
         if (config.generateData()) {
             int randomSeed = 0;
             DataGenerator dataGenerator = new DataGenerator(session, config, randomSeed);
-            dataGenerator.loadSchema();
 
             List<Integer> numConceptsInRun = config.scalesToProfile();
             for (int numConcepts : numConceptsInRun) {

--- a/runner/test-end-to-end/BUILD
+++ b/runner/test-end-to-end/BUILD
@@ -1,0 +1,15 @@
+java_test(
+    name = "test-end-to-end",
+    test_class = "grakn.benchmark.runner.SchemaManagerE2E",
+    srcs = ["SchemaManagerE2E.java"],
+    deps = [
+        "//runner:benchmark-runner",
+        "//dependencies/maven/artifacts/grakn/core:client",
+        "//dependencies/maven/artifacts/grakn/core:grakn-graql",
+        "//dependencies/maven/artifacts/grakn/core:util",
+    ],
+    classpath_resources = ["//runner/test/resources:logback-test"],
+    data = [
+        "//runner/test/resources:web-content-config"
+    ]
+)

--- a/runner/test-end-to-end/SchemaManagerE2E.java
+++ b/runner/test-end-to-end/SchemaManagerE2E.java
@@ -1,0 +1,73 @@
+package grakn.benchmark.runner;
+
+import grakn.benchmark.runner.exception.BootupException;
+import grakn.core.GraknTxType;
+import grakn.core.Keyspace;
+import grakn.core.client.Grakn;
+import grakn.core.graql.answer.ConceptMap;
+import grakn.core.util.SimpleURI;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.UUID;
+
+import static grakn.core.graql.Graql.var;
+
+public class SchemaManagerE2E {
+    private final static Path WEB_CONTENT_CONFIG_PATH = Paths.get("runner/test/resources/web_content/web_content_config_test.yml");
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+    private Grakn client;
+    private Grakn.Session session;
+    private Keyspace keyspace;
+
+    @Before
+    public void setUp() {
+        client = new Grakn(new SimpleURI("localhost:48555"));
+        String uuid = UUID.randomUUID().toString().substring(0, 30).replace("-", "");
+        keyspace = Keyspace.of("test_" + uuid);
+        session = client.session(keyspace);
+    }
+
+    @After
+    public void tearDown() {
+        client.keyspaces().delete(keyspace);
+        session.close();
+    }
+
+    @Test
+    public void whenSchemaExistsInKeyspace_ThrowException() {
+
+        try (Grakn.Transaction tx = session.transaction(GraknTxType.WRITE)) {
+            List<ConceptMap> answer = tx.graql().define(var("x").sub("entity").label("person")).execute();
+            tx.commit();
+        }
+
+        expectedException.expect(BootupException.class);
+        expectedException.expectMessage("not empty, contains a schema");
+        GraknBenchmark graknBenchmark = new GraknBenchmark(new String[]{"--config", WEB_CONTENT_CONFIG_PATH.toAbsolutePath().toString(), "--keyspace", keyspace.toString()});
+        graknBenchmark.start();
+    }
+
+    @Test
+    public void whenDataExistsInKeyspace_ThrowException() {
+
+        try (Grakn.Transaction tx = session.transaction(GraknTxType.WRITE)) {
+            List<ConceptMap> answer = tx.graql().define(var("x").sub("entity").label("person")).execute();
+            answer = tx.graql().insert(var("x").isa("person")).execute();
+            tx.commit();
+        }
+
+        expectedException.expect(BootupException.class);
+        expectedException.expectMessage("not empty, contains concept instances");
+        GraknBenchmark graknBenchmark = new GraknBenchmark(new String[]{"--config", WEB_CONTENT_CONFIG_PATH.toAbsolutePath().toString(), "--keyspace", keyspace.toString()});
+        graknBenchmark.start();
+    }
+}


### PR DESCRIPTION
Add functionality to test for attempting to use keyspaces that are not empty, so failures aren't silent anymore.

Fix ingnite Table not found errors caused by out of order initialization after recent refactor, which meant that the schema was being initialized after ignite tables were being set up (whereas the ignite tables are created based on the loaded schema for correct functionality).