### PR TITLE
Add --elastic-uri parameter to GraknBenchmark

### DIFF
--- a/runner/conf/societal_model/societal_config_1.yml
+++ b/runner/conf/societal_model/societal_config_1.yml
@@ -2,7 +2,7 @@ name: "societal_model"
 schema: "societal_model.gql"
 queries: "queries.yml"
 scales:
-  - 40000
+  - 500
 repeatsPerQuery: 0
 # TODO
 # concurrency:

--- a/runner/conf/web_content/web_content_config.yml
+++ b/runner/conf/web_content/web_content_config.yml
@@ -2,7 +2,7 @@ name: "web_content"
 schema: "web_content_schema.gql"
 queries: "queries.yml"
 scales:
-  - 2000
+  - 500
 repeatsPerQuery: 5
 # TODO
 # concurrency:

--- a/runner/src/GraknBenchmark.java
+++ b/runner/src/GraknBenchmark.java
@@ -63,10 +63,9 @@ public class GraknBenchmark {
         try {
             // Parse the configuration for the benchmark
             CommandLine arguments = BenchmarkArguments.parse(args);
-            BenchmarkConfiguration benchmarkConfig = new BenchmarkConfiguration(arguments);
-            ElasticSearchManager.init(benchmarkConfig.elasticUri());
 
-            GraknBenchmark benchmark = new GraknBenchmark(args);
+            ElasticSearchManager.init(arguments);
+            GraknBenchmark benchmark = new GraknBenchmark(arguments);
             benchmark.start();
         } catch (Exception e) {
             exitCode = 1;
@@ -77,8 +76,7 @@ public class GraknBenchmark {
         }
     }
 
-    public GraknBenchmark(String[] args) {
-        CommandLine arguments = BenchmarkArguments.parse(args);
+    public GraknBenchmark(CommandLine arguments) {
         BenchmarkConfiguration benchmarkConfig = new BenchmarkConfiguration(arguments);
         this.config = benchmarkConfig;
 

--- a/runner/src/util/BenchmarkArguments.java
+++ b/runner/src/util/BenchmarkArguments.java
@@ -14,10 +14,11 @@ import org.apache.commons.cli.ParseException;
 public class BenchmarkArguments {
 
     public final static String CONFIG_ARGUMENT = "config";
-    public final static String URI_ARGUMENT = "uri";
+    public final static String GRAKN_URI = "grakn-uri";
     public final static String KEYSPACE_ARGUMENT = "keyspace";
     public final static String NO_DATA_GENERATION_ARGUMENT = "no-data-generation";
     public final static String EXECUTION_NAME_ARGUMENT = "execution-name";
+    public final static String ELASTIC_URI = "elastic-uri";
 
     public static CommandLine parse(String[] args) {
         Options options = buildOptions();
@@ -40,7 +41,7 @@ public class BenchmarkArguments {
                 .build();
 
         Option graknAddressOption = Option.builder("u")
-                .longOpt(URI_ARGUMENT)
+                .longOpt(GRAKN_URI)
                 .hasArg(true)
                 .desc("Address of the grakn cluster (default: localhost:48555)")
                 .required(false)
@@ -67,12 +68,20 @@ public class BenchmarkArguments {
                 .desc("Name for specific execution of the config file")
                 .type(String.class)
                 .build();
+        Option elasticsearchAddressOption = Option.builder("e")
+                .longOpt(ELASTIC_URI)
+                .hasArg(true)
+                .desc("Address of the elastic search server (default: localhost:9200")
+                .required(false)
+                .type(String.class)
+                .build();
         Options options = new Options();
         options.addOption(configFileOption);
         options.addOption(graknAddressOption);
         options.addOption(keyspaceOption);
         options.addOption(noDataGenerationOption);
         options.addOption(executionNameOption);
+        options.addOption(elasticsearchAddressOption);
         return options;
     }
 }

--- a/runner/src/util/BenchmarkConfiguration.java
+++ b/runner/src/util/BenchmarkConfiguration.java
@@ -43,7 +43,6 @@ import static grakn.benchmark.runner.util.BenchmarkArguments.*;
 public class BenchmarkConfiguration {
 
     private static final String DEFAULT_GRAKN_URI = "localhost:48555";
-    private static final String DEFAULT_ELASTIC_URI = "localhost:9200";
 
     private final boolean generateData;
     private List<String> queries;
@@ -51,7 +50,6 @@ public class BenchmarkConfiguration {
     private BenchmarkConfigurationFile benchmarkConfigFile;
     private String keyspace;
     private String graknUri;
-    private String elasticUri;
     private String executionName;
 
     public BenchmarkConfiguration(CommandLine arguments) {
@@ -71,8 +69,6 @@ public class BenchmarkConfiguration {
 
         this.graknUri = (arguments.hasOption(GRAKN_URI)) ? arguments.getOptionValue(GRAKN_URI) : DEFAULT_GRAKN_URI;
 
-        this.elasticUri = (arguments.hasOption(ELASTIC_URI)) ? arguments.getOptionValue(ELASTIC_URI) : DEFAULT_ELASTIC_URI;
-
         this.executionName = (arguments.hasOption(EXECUTION_NAME_ARGUMENT)) ? arguments.getOptionValue(EXECUTION_NAME_ARGUMENT) : "";
 
         // If --no-data-generation is specified, don't generate any data (work with existing keyspace)
@@ -85,10 +81,6 @@ public class BenchmarkConfiguration {
 
     public String graknUri() {
         return graknUri;
-    }
-
-    public String elasticUri() {
-        return elasticUri;
     }
 
     public String executionName() {

--- a/runner/src/util/BenchmarkConfiguration.java
+++ b/runner/src/util/BenchmarkConfiguration.java
@@ -32,10 +32,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
-import static grakn.benchmark.runner.util.BenchmarkArguments.CONFIG_ARGUMENT;
-import static grakn.benchmark.runner.util.BenchmarkArguments.KEYSPACE_ARGUMENT;
-import static grakn.benchmark.runner.util.BenchmarkArguments.NO_DATA_GENERATION_ARGUMENT;
-import static grakn.benchmark.runner.util.BenchmarkArguments.URI_ARGUMENT;
+import static grakn.benchmark.runner.util.BenchmarkArguments.*;
 
 /**
  * This class parses multiple yaml files into object and wraps them
@@ -46,13 +43,16 @@ import static grakn.benchmark.runner.util.BenchmarkArguments.URI_ARGUMENT;
 public class BenchmarkConfiguration {
 
     private static final String DEFAULT_GRAKN_URI = "localhost:48555";
+    private static final String DEFAULT_ELASTIC_URI = "localhost:9200";
 
     private final boolean generateData;
     private List<String> queries;
     private List<String> graqlSchema;
     private BenchmarkConfigurationFile benchmarkConfigFile;
     private String keyspace;
-    private String uri;
+    private String graknUri;
+    private String elasticUri;
+    private String executionName;
 
     public BenchmarkConfiguration(CommandLine arguments) {
         Path configFilePath = getConfigFilePath(arguments);
@@ -69,7 +69,11 @@ public class BenchmarkConfiguration {
         // use given keyspace string if exists, otherwise use yaml file `name` tag
         this.keyspace = arguments.hasOption(KEYSPACE_ARGUMENT) ? arguments.getOptionValue(KEYSPACE_ARGUMENT) : this.getConfigName();
 
-        this.uri = (arguments.hasOption(URI_ARGUMENT)) ? arguments.getOptionValue(URI_ARGUMENT) : DEFAULT_GRAKN_URI;
+        this.graknUri = (arguments.hasOption(GRAKN_URI)) ? arguments.getOptionValue(GRAKN_URI) : DEFAULT_GRAKN_URI;
+
+        this.elasticUri = (arguments.hasOption(ELASTIC_URI)) ? arguments.getOptionValue(ELASTIC_URI) : DEFAULT_ELASTIC_URI;
+
+        this.executionName = (arguments.hasOption(EXECUTION_NAME_ARGUMENT)) ? arguments.getOptionValue(EXECUTION_NAME_ARGUMENT) : "";
 
         // If --no-data-generation is specified, don't generate any data (work with existing keyspace)
         this.generateData = !(arguments.hasOption(NO_DATA_GENERATION_ARGUMENT));
@@ -79,8 +83,16 @@ public class BenchmarkConfiguration {
         return this.benchmarkConfigFile.getName();
     }
 
-    public String uri() {
-        return uri;
+    public String graknUri() {
+        return graknUri;
+    }
+
+    public String elasticUri() {
+        return elasticUri;
+    }
+
+    public String executionName() {
+        return executionName;
     }
 
     public Keyspace getKeyspace() {

--- a/runner/src/util/ElasticSearchManager.java
+++ b/runner/src/util/ElasticSearchManager.java
@@ -1,5 +1,6 @@
 package grakn.benchmark.runner.util;
 
+import org.apache.commons.cli.CommandLine;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
@@ -15,9 +16,13 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
+import static grakn.benchmark.runner.util.BenchmarkArguments.ELASTIC_URI;
+
 public class ElasticSearchManager {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticSearchManager.class);
     private static final String ES_SERVER_PROTOCOL = "http";
+    private static final String ES_SERVER_HOST = "localhost";
+    private static final int ES_SERVER_PORT = 9200;
     private static final String ES_INDEX_TEMPLATE_NAME = "grakn-benchmark-index-template";
     private static final String INDEX_TEMPLATE =
             "{"+
@@ -88,11 +93,19 @@ public class ElasticSearchManager {
         }
     }
 
-    public static void init(String elasticUri) throws IOException {
-        int splitIndex = elasticUri.lastIndexOf(":");
-        String esServerHost = elasticUri.substring(0, splitIndex);
-        Integer esServerPort = Integer.parseInt(elasticUri.substring(splitIndex+1));
-        RestClientBuilder esRestClientBuilder = RestClient.builder(new HttpHost(esServerHost, esServerPort, ES_SERVER_PROTOCOL));
+    public static void init(CommandLine arguments) throws IOException {
+        RestClientBuilder esRestClientBuilder;
+
+        if (arguments.hasOption(ELASTIC_URI)) {
+            String elasticUri = arguments.getOptionValue(ELASTIC_URI);
+            int splitIndex = elasticUri.lastIndexOf(":");
+            String esServerHost = elasticUri.substring(0, splitIndex);
+            Integer esServerPort = Integer.parseInt(elasticUri.substring(splitIndex+1));
+            esRestClientBuilder = RestClient.builder(new HttpHost(esServerHost, esServerPort, ES_SERVER_PROTOCOL));
+        } else {
+            esRestClientBuilder = RestClient.builder(new HttpHost(ES_SERVER_HOST, ES_SERVER_PORT, ES_SERVER_PROTOCOL));
+        }
+
         esRestClientBuilder.setDefaultHeaders(new Header[]{new BasicHeader("header", "value")});
         RestClient restClient = esRestClientBuilder.build();
 

--- a/runner/src/util/ElasticSearchManager.java
+++ b/runner/src/util/ElasticSearchManager.java
@@ -17,9 +17,6 @@ import java.io.IOException;
 
 public class ElasticSearchManager {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticSearchManager.class);
-
-    private static final String ES_SERVER_HOST = "localhost";
-    private static final int ES_SERVER_PORT = 9200;
     private static final String ES_SERVER_PROTOCOL = "http";
     private static final String ES_INDEX_TEMPLATE_NAME = "grakn-benchmark-index-template";
     private static final String INDEX_TEMPLATE =
@@ -91,8 +88,11 @@ public class ElasticSearchManager {
         }
     }
 
-    public static void init() throws IOException {
-        RestClientBuilder esRestClientBuilder = RestClient.builder(new HttpHost(ES_SERVER_HOST, ES_SERVER_PORT, ES_SERVER_PROTOCOL));
+    public static void init(String elasticUri) throws IOException {
+        int splitIndex = elasticUri.lastIndexOf(":");
+        String esServerHost = elasticUri.substring(0, splitIndex);
+        Integer esServerPort = Integer.parseInt(elasticUri.substring(splitIndex+1));
+        RestClientBuilder esRestClientBuilder = RestClient.builder(new HttpHost(esServerHost, esServerPort, ES_SERVER_PROTOCOL));
         esRestClientBuilder.setDefaultHeaders(new Header[]{new BasicHeader("header", "value")});
         RestClient restClient = esRestClientBuilder.build();
 

--- a/runner/test-end-to-end/BUILD
+++ b/runner/test-end-to-end/BUILD
@@ -7,6 +7,7 @@ java_test(
         "//dependencies/maven/artifacts/grakn/core:client",
         "//dependencies/maven/artifacts/grakn/core:grakn-graql",
         "//dependencies/maven/artifacts/grakn/core:util",
+        "//dependencies/maven/artifacts/commons-cli"
     ],
     classpath_resources = ["//runner/test/resources:logback-test"],
     data = [

--- a/runner/test-end-to-end/SchemaManagerE2E.java
+++ b/runner/test-end-to-end/SchemaManagerE2E.java
@@ -1,11 +1,13 @@
 package grakn.benchmark.runner;
 
 import grakn.benchmark.runner.exception.BootupException;
+import grakn.benchmark.runner.util.BenchmarkArguments;
 import grakn.core.GraknTxType;
 import grakn.core.Keyspace;
 import grakn.core.client.Grakn;
 import grakn.core.graql.answer.ConceptMap;
 import grakn.core.util.SimpleURI;
+import org.apache.commons.cli.CommandLine;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -52,7 +54,9 @@ public class SchemaManagerE2E {
 
         expectedException.expect(BootupException.class);
         expectedException.expectMessage("not empty, contains a schema");
-        GraknBenchmark graknBenchmark = new GraknBenchmark(new String[]{"--config", WEB_CONTENT_CONFIG_PATH.toAbsolutePath().toString(), "--keyspace", keyspace.toString()});
+        String[] args = new String[]{"--config", WEB_CONTENT_CONFIG_PATH.toAbsolutePath().toString(), "--keyspace", keyspace.toString()};
+        CommandLine commandLine = BenchmarkArguments.parse(args);
+        GraknBenchmark graknBenchmark = new GraknBenchmark(commandLine);
         graknBenchmark.start();
     }
 
@@ -67,7 +71,9 @@ public class SchemaManagerE2E {
 
         expectedException.expect(BootupException.class);
         expectedException.expectMessage("not empty, contains concept instances");
-        GraknBenchmark graknBenchmark = new GraknBenchmark(new String[]{"--config", WEB_CONTENT_CONFIG_PATH.toAbsolutePath().toString(), "--keyspace", keyspace.toString()});
+        String[] args = new String[] {"--config", WEB_CONTENT_CONFIG_PATH.toAbsolutePath().toString(), "--keyspace", keyspace.toString()};
+        CommandLine commandLine = BenchmarkArguments.parse(args);
+        GraknBenchmark graknBenchmark = new GraknBenchmark(commandLine);
         graknBenchmark.start();
     }
 }

--- a/runner/test/BUILD
+++ b/runner/test/BUILD
@@ -2,7 +2,10 @@ java_test(
     name = "benchmark-test",
     test_class = "grakn.benchmark.runner.GraknBenchmarkTest",
     srcs = ["GraknBenchmarkTest.java"],
-    deps = ["//runner:benchmark-runner"],
+    deps = [
+        "//runner:benchmark-runner",
+        "//dependencies/maven/artifacts/commons-cli",
+    ],
     classpath_resources = ["//runner/test/resources:logback-test"],
     data = [
         "//runner/test/resources:web-content-config"

--- a/runner/test/GraknBenchmarkTest.java
+++ b/runner/test/GraknBenchmarkTest.java
@@ -1,9 +1,11 @@
 package grakn.benchmark.runner;
 
 import grakn.benchmark.runner.exception.BootupException;
+import grakn.benchmark.runner.util.BenchmarkArguments;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.apache.commons.cli.CommandLine;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -21,26 +23,32 @@ public class GraknBenchmarkTest {
 
     @Test
     public void whenProvidingAbsolutePathToExistingConfig_benchmarkShouldStart() {
-        GraknBenchmark graknBenchmark = new GraknBenchmark(new String[]{"--config", WEB_CONTENT_CONFIG_PATH.toAbsolutePath().toString()});
+        String[] args = new String[]{"--config", WEB_CONTENT_CONFIG_PATH.toAbsolutePath().toString()};
+        CommandLine commandLine = BenchmarkArguments.parse(args);
+        GraknBenchmark graknBenchmark = new GraknBenchmark(commandLine);
     }
 
     @Test
     public void whenProvidingRelativePathToExistingConfig_benchmarkShouldStart() {
+        String[] args = new String[]{"--config", "web_content_config_test.yml"};
         System.setProperty("working.dir", WEB_CONTENT_CONFIG_PATH.getParent().toString());
-        GraknBenchmark graknBenchmark = new GraknBenchmark(new String[]{"--config", "web_content_config_test.yml"});
+        CommandLine commandLine = BenchmarkArguments.parse(args);
+        GraknBenchmark graknBenchmark = new GraknBenchmark(commandLine);
     }
 
     @Test
     public void whenProvidingAbsolutePathToNonExistingConfig_throwException() {
+        String[] args = new String[]{"--config", "nonexistingpath"};
+        CommandLine commandLine = BenchmarkArguments.parse(args);
         expectedException.expect(BootupException.class);
         expectedException.expectMessage("The provided config file [nonexistingpath] does not exist");
-        GraknBenchmark graknBenchmark = new GraknBenchmark(new String[]{"--config", "nonexistingpath"});
+        GraknBenchmark graknBenchmark = new GraknBenchmark(commandLine);
     }
 
     @Test
     public void whenConfigurationArgumentNotProvided_throwException() {
         expectedException.expect(BootupException.class);
         expectedException.expectMessage("Missing required option: c");
-        GraknBenchmark graknBenchmark = new GraknBenchmark(new String[]{});
+        GraknBenchmark graknBenchmark = new GraknBenchmark(BenchmarkArguments.parse(new String[] {}));
     }
 }


### PR DESCRIPTION
Add --elastic-uri parameter to the benchmark distribution which is needed when elastic server is not on localhost.
