### PR TITLE
Update zipkin tracing tags and ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ is present, and in the BUILD file this dependency is referenced.
 
 ### 3. Visualise Results In Benchmark-Dashboard
 
+NOTE: This dashboard is the first version produced to visualize our tracing results from Zipkin.
+The last expected compatible version of `benchmark` is ec2272bb2f614a424de4498e968e5b1a7497c32a
+After this, the structure of spans has changed (eg. no more `batchSpan`, change order query repetitions)
+
 The visualisation dashboard reads ElasticSearch and creates graphs via Dash and Plotly.
 
 Getting it up and running requires `pipenv` and Python >=3.6.0

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Check if Elasticsearch is running by accessing http://localhost:9200 from the br
 In the Zipkin installation directory, do:
 
 ```
-$ STORAGE_TYPE=elasticsearch ES_HOSTS=http://localhost:9200 ES_INDEX="benchmarking" java -jar zipkin.jar
+$ STORAGE_TYPE=elasticsearch ES_HOSTS=http://localhost:9200 ES_INDEX="benchmark" java -jar zipkin.jar
 ```
 Check if Zipkin is running by accessing http://localhost:9411/zipkin/ from the browser.
 
@@ -68,7 +68,7 @@ The entry point to rebuild, generate, and name executions of config files is `ru
 
 Basic usage:
 
-`benchmark --config grakn-benchmark/src/main/resources/societal_config_1.yml --execution-name query-plan-mod-1 --keyspace benchmark --ignite-dir /Users/user/Documents/benchmarking-reqs/apache-ignite-fabric-2.6.0-bin/`
+`benchmark --config grakn-benchmark/src/main/resources/societal_config_1.yml --execution-name query-plan-mod-1 --keyspace benchmark` 
 
 Notes:
 

--- a/dashboard/ZipkinESStorage.py
+++ b/dashboard/ZipkinESStorage.py
@@ -3,7 +3,7 @@ import elasticsearch.helpers as helpers
 
 class ZipkinESStorage(object):
 
-    def __init__(self, indices="benchmarking:*"):
+    def __init__(self, indices="benchmark:*"):
         """ Create a connection to ES _and_ check that the required templates are in it """
         self.es = elasticsearch.Elasticsearch()
         self.indices = indices

--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -6,6 +6,15 @@ from ZipkinESStorage import ZipkinESStorage
 from ExecutionSelector import ExecutionSelector
 from ExecutionVisualiser.ExecutionVisualiser import ExecutionVisualiser
 
+"""
+
+This dashboard is the first version produced to visualize our tracing results from Zipkin.
+The last expected compatible version of `benchmark` is ec2272bb2f614a424de4498e968e5b1a7497c32a
+After this, the structure of spans has changed (eg. no more `batchSpan`, change order query repetitions)
+
+
+"""
+
 
 class Dashboard(object):
     def __init__(self, max_interactive_graphs_per_execution=100):

--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -93,7 +93,7 @@ class Dashboard(object):
         )
 
         layout = html.Div(children=[
-            html.H1("Grakn Benchmarking Dashboard"),
+            html.H1("Grakn Benchmark Dashboard"),
             html.Div(
                 className="container-fluid",
                 children=[

--- a/runner/conf/societal_model/societal_config_1.yml
+++ b/runner/conf/societal_model/societal_config_1.yml
@@ -1,4 +1,4 @@
-name: "societal_model"
+graphName: "societal_model"
 schema: "societal_model.gql"
 queries: "queries.yml"
 scales:
@@ -8,5 +8,5 @@ repeatsPerQuery: 0
 # concurrency:
 #   clients: 1
   # mixed:
-# replication: 1
+# replication:
 

--- a/runner/conf/web_content/web_content_config.yml
+++ b/runner/conf/web_content/web_content_config.yml
@@ -1,9 +1,9 @@
-name: "web_content"
+graphName: "web_content"
 schema: "web_content_schema.gql"
 queries: "queries.yml"
 scales:
-  - 1000
-repeatsPerQuery: 0
+  - 500
+repeatsPerQuery: 1
 # TODO
 # concurrency:
 #   clients: 1

--- a/runner/setup.sh
+++ b/runner/setup.sh
@@ -70,7 +70,7 @@ done
 echo
 
 echo -n "Starting Zipkin"
-ES_HOSTS=http://localhost:9200 env ES_INDEX="benchmarking" java -jar $BENCHMARK_RUNNER_EXTERNAL_DEPS_DIR/zipkin.jar &
+ES_HOSTS=http://localhost:9200 env ES_INDEX="benchmark" java -jar $BENCHMARK_RUNNER_EXTERNAL_DEPS_DIR/zipkin.jar &
 zipkin_pid=$!
 until $(curl --output /dev/null --silent --head --fail localhost:9411); do
   echo -n "."

--- a/runner/src/GraknBenchmark.java
+++ b/runner/src/GraknBenchmark.java
@@ -51,7 +51,6 @@ public class GraknBenchmark {
     private static final Logger LOG = LoggerFactory.getLogger(GraknBenchmark.class);
 
     private final BenchmarkConfiguration config;
-    private final String executionName;
 
     /**
      * Entry point invoked by benchmark script
@@ -79,11 +78,6 @@ public class GraknBenchmark {
     public GraknBenchmark(CommandLine arguments) {
         BenchmarkConfiguration benchmarkConfig = new BenchmarkConfiguration(arguments);
         this.config = benchmarkConfig;
-
-        // generate a name for this specific execution of the benchmarking
-        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm");
-        String dateString = dateFormat.format(new Date());
-        this.executionName = String.join(" ", Arrays.asList(dateString, config.graphName(), config.executionName())).trim();
     }
 
 
@@ -96,7 +90,7 @@ public class GraknBenchmark {
         Grakn client = new Grakn(new SimpleURI(config.graknUri()), true);
         Grakn.Session session = client.session(config.getKeyspace());
         SchemaManager.verifyEmptyKeyspace(session);
-        QueryProfiler queryProfiler = new QueryProfiler(session, executionName, config.graphName(), config.getQueries());
+        QueryProfiler queryProfiler = new QueryProfiler(session, config.executionName(), config.graphName(), config.getQueries());
         int repetitionsPerQuery = config.numQueryRepetitions();
 
         //TODO add check to make sure currentKeyspace does not exist, if it does throw exception

--- a/runner/src/GraknBenchmark.java
+++ b/runner/src/GraknBenchmark.java
@@ -83,7 +83,7 @@ public class GraknBenchmark {
         // generate a name for this specific execution of the benchmarking
         DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm");
         String dateString = dateFormat.format(new Date());
-        this.executionName = String.join(" ", Arrays.asList(dateString, config.getConfigName(), config.executionName())).trim();
+        this.executionName = String.join(" ", Arrays.asList(dateString, config.graphName(), config.executionName())).trim();
     }
 
 
@@ -96,7 +96,7 @@ public class GraknBenchmark {
         Grakn client = new Grakn(new SimpleURI(config.graknUri()), true);
         Grakn.Session session = client.session(config.getKeyspace());
         SchemaManager.verifyEmptyKeyspace(session);
-        QueryProfiler queryProfiler = new QueryProfiler(session, executionName, config.getQueries());
+        QueryProfiler queryProfiler = new QueryProfiler(session, executionName, config.graphName(), config.getQueries());
         int repetitionsPerQuery = config.numQueryRepetitions();
 
         //TODO add check to make sure currentKeyspace does not exist, if it does throw exception

--- a/runner/src/GraknBenchmark.java
+++ b/runner/src/GraknBenchmark.java
@@ -108,7 +108,7 @@ public class GraknBenchmark {
             }
         } else {
             int numConcepts = queryProfiler.aggregateCount();
-            queryProfiler.processStaticQueries(repetitionsPerQuery, numConcepts, "Preconfigured DB - no data gen");
+            queryProfiler.processStaticQueries(repetitionsPerQuery, numConcepts);
         }
 
         session.close();

--- a/runner/src/executor/QueryProfiler.java
+++ b/runner/src/executor/QueryProfiler.java
@@ -45,13 +45,15 @@ public class QueryProfiler {
     private static final Logger LOG = LoggerFactory.getLogger(QueryProfiler.class);
 
     private final String executionName;
+    private final String graphName;
     private final List<Query> queries;
     private final Grakn.Session session;
 
-    public QueryProfiler(Grakn.Session session, String executionName, List<String> queryStrings) {
+    public QueryProfiler(Grakn.Session session, String executionName, String graphName, List<String> queryStrings) {
         this.session = session;
 
         this.executionName = executionName;
+        this.graphName = graphName;
 
         // convert Graql strings into Query types
         this.queries = queryStrings.stream()
@@ -99,10 +101,11 @@ public class QueryProfiler {
                 LOG.info("Running query: " + query.toString());
 
                 Span batchSpan = tracer.newTrace().name("batch-query");
-                batchSpan.tag("concepts", Integer.toString(numConcepts));
+                batchSpan.tag("scale", Integer.toString(numConcepts));
                 batchSpan.tag("query", query.toString());
                 batchSpan.tag("executionName", this.executionName);
                 batchSpan.tag("repetitions", Integer.toString(numRepeats));
+                batchSpan.tag("graphName", this.graphName);
                 if (msg != null) {
                     batchSpan.tag("extraTag", msg);
                 }

--- a/runner/src/executor/QueryProfiler.java
+++ b/runner/src/executor/QueryProfiler.java
@@ -61,16 +61,12 @@ public class QueryProfiler {
                         .collect(Collectors.toList());
     }
 
-    public void processStaticQueries(int numRepeats, int numConcepts, String extraMessage) {
+    public void processStaticQueries(int numRepeats, int numConcepts) {
         try {
-            this.processQueries(queries.stream(), numRepeats, numConcepts, extraMessage);
+            this.processQueries(queries.stream(), numRepeats, numConcepts);
         } catch (Exception e) {
             e.printStackTrace();
         }
-    }
-
-    public void processStaticQueries(int numRepeats, int numConcepts) {
-        processStaticQueries(numRepeats, numConcepts, null);
     }
 
     public int aggregateCount() {
@@ -80,58 +76,43 @@ public class QueryProfiler {
         }
     }
 
-    /**
-     *
-     * @param queryStream stream of Graql queries
-     * @param numRepeats
-     * @param numConcepts
-     * @param msg
-     * @throws Exception
-     */
-    void processQueries(Stream<Query> queryStream, int numRepeats, int numConcepts, String msg) throws Exception {
+    void processQueries(Stream<Query> queryStream, int repetitions, int numConcepts) throws Exception {
 
         try (Grakn.Transaction tx = session.transaction(GraknTxType.WRITE)) {
             Tracer tracer = Tracing.currentTracer();
 
-            Iterator<Query> queryIterator = queryStream.iterator();
-            int counter = 0;
-            while (queryIterator.hasNext()) {
+            List<Query> queries = queryStream.collect(Collectors.toList());
 
-                Query query = queryIterator.next().withTx(tx);
-                LOG.info("Running query: " + query.toString());
+            for (int rep = 0; rep < repetitions; rep++) {
 
-                Span batchSpan = tracer.newTrace().name("batch-query");
-                batchSpan.tag("scale", Integer.toString(numConcepts));
-                batchSpan.tag("query", query.toString());
-                batchSpan.tag("executionName", this.executionName);
-                batchSpan.tag("repetitions", Integer.toString(numRepeats));
-                batchSpan.tag("graphName", this.graphName);
-                if (msg != null) {
-                    batchSpan.tag("extraTag", msg);
-                }
-                batchSpan.start();
+                for (Query rawQuery : queries) {
+                    Query query = rawQuery.withTx(tx);
 
-                for (int i = 0; i < numRepeats; i++) {
+                    LOG.info("Running query iteration " + rep + ": " + query.toString());
+                    Span querySpan = tracer.newTrace().name("query");
+                    querySpan.tag("scale", Integer.toString(numConcepts));
+                    querySpan.tag("query", query.toString());
+                    querySpan.tag("executionName", this.executionName);
+                    querySpan.tag("repetitions", Integer.toString(repetitions));
+                    querySpan.tag("graphName", this.graphName);
+                    querySpan.tag("repetition", Integer.toString(rep));
+                    querySpan.start();
 
-                    Span span = tracer.newChild(batchSpan.context()).name("query-repetition");
-                    span.tag("repetition", Integer.toString(i));
-                    span.start();
-
-                    try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
+                    // perform trace in thread-local storage on the client
+                    try (Tracer.SpanInScope ws = tracer.withSpanInScope(querySpan)) {
                         List<Answer> answer = query.execute();
                     } catch (RuntimeException | Error e) {
-                        span.error(e);
+                        querySpan.error(e);
                         throw e;
                     } finally {
-                        span.finish();
+                        querySpan.finish();
                     }
-                    counter ++;
                 }
-                batchSpan.finish();
+                // wait for out-of-band reporting to complete
                 Thread.sleep(500);
             }
+            // wait for out-of-band reporting to complete
             Thread.sleep(1500);
-            System.out.println(counter);
         }
     }
 }

--- a/runner/src/generator/DataGenerator.java
+++ b/runner/src/generator/DataGenerator.java
@@ -46,7 +46,7 @@ public class DataGenerator {
     private static final Logger LOG = LoggerFactory.getLogger(DataGenerator.class);
 
     private final Grakn.Session session;
-    private final String executionName;
+    private final String graphName ;
     private final List<String> schemaDefinition;
     private int iteration;
     private Random rand;
@@ -57,7 +57,7 @@ public class DataGenerator {
 
     public DataGenerator(Grakn.Session session, BenchmarkConfiguration config, int randomSeed) {
         this.session = session;
-        this.executionName = config.getConfigName();
+        this.graphName = config.graphName();
         this.rand = new Random(randomSeed);
         this.iteration = 0;
         this.schemaDefinition = config.getGraqlSchema();
@@ -78,7 +78,7 @@ public class DataGenerator {
             LOG.info("Initialising ignite...");
             this.storage = new IgniteConceptIdStore(entityTypes, relationshipTypes, attributeTypes);
         }
-        this.dataStrategies = SchemaSpecificDataGeneratorFactory.getSpecificStrategy(this.executionName, this.rand, this.storage);
+        this.dataStrategies = SchemaSpecificDataGeneratorFactory.getSpecificStrategy(this.graphName, this.rand, this.storage);
     }
 
     public void generate(int graphScaleLimit) {

--- a/runner/src/util/BenchmarkArguments.java
+++ b/runner/src/util/BenchmarkArguments.java
@@ -39,7 +39,13 @@ public class BenchmarkArguments {
                 .required(true)
                 .type(String.class)
                 .build();
-
+        Option executionNameOption = Option.builder("n")
+                .longOpt(EXECUTION_NAME_ARGUMENT)
+                .hasArg(true)
+                .required(true)
+                .desc("Name for specific execution, this label is passed through to the storage backend")
+                .type(String.class)
+                .build();
         Option graknAddressOption = Option.builder("u")
                 .longOpt(GRAKN_URI)
                 .hasArg(true)
@@ -60,13 +66,6 @@ public class BenchmarkArguments {
                 .required(false)
                 .desc("Disable data generation")
                 .type(Boolean.class)
-                .build();
-        Option executionNameOption = Option.builder("n")
-                .longOpt(EXECUTION_NAME_ARGUMENT)
-                .hasArg(true)
-                .required(false)
-                .desc("Name for specific execution of the config file")
-                .type(String.class)
                 .build();
         Option elasticsearchAddressOption = Option.builder("e")
                 .longOpt(ELASTIC_URI)

--- a/runner/src/util/BenchmarkConfiguration.java
+++ b/runner/src/util/BenchmarkConfiguration.java
@@ -51,6 +51,7 @@ public class BenchmarkConfiguration {
     private String keyspace;
     private String graknUri;
     private String executionName;
+    private String graphName;
 
     public BenchmarkConfiguration(CommandLine arguments) {
         Path configFilePath = getConfigFilePath(arguments);
@@ -65,7 +66,7 @@ public class BenchmarkConfiguration {
         this.graqlSchema = parseGraqlSchema(configFilePath);
 
         // use given keyspace string if exists, otherwise use yaml file `name` tag
-        this.keyspace = arguments.hasOption(KEYSPACE_ARGUMENT) ? arguments.getOptionValue(KEYSPACE_ARGUMENT) : this.getConfigName();
+        this.keyspace = arguments.hasOption(KEYSPACE_ARGUMENT) ? arguments.getOptionValue(KEYSPACE_ARGUMENT) : this.graphName();
 
         this.graknUri = (arguments.hasOption(GRAKN_URI)) ? arguments.getOptionValue(GRAKN_URI) : DEFAULT_GRAKN_URI;
 
@@ -76,7 +77,7 @@ public class BenchmarkConfiguration {
     }
 
     public String getConfigName() {
-        return this.benchmarkConfigFile.getName();
+        return this.benchmarkConfigFile.getGraphName();
     }
 
     public String graknUri() {
@@ -86,6 +87,8 @@ public class BenchmarkConfiguration {
     public String executionName() {
         return executionName;
     }
+
+    public String graphName() { return this.benchmarkConfigFile.getGraphName(); }
 
     public Keyspace getKeyspace() {
         return Keyspace.of(this.keyspace);

--- a/runner/src/util/BenchmarkConfiguration.java
+++ b/runner/src/util/BenchmarkConfiguration.java
@@ -56,6 +56,8 @@ public class BenchmarkConfiguration {
     public BenchmarkConfiguration(CommandLine arguments) {
         Path configFilePath = getConfigFilePath(arguments);
 
+        this.executionName = arguments.getOptionValue(EXECUTION_NAME_ARGUMENT);
+
         // Parse yaml file with generic configurations
         this.benchmarkConfigFile = parseConfigurationFile(configFilePath);
 
@@ -69,8 +71,6 @@ public class BenchmarkConfiguration {
         this.keyspace = arguments.hasOption(KEYSPACE_ARGUMENT) ? arguments.getOptionValue(KEYSPACE_ARGUMENT) : this.graphName();
 
         this.graknUri = (arguments.hasOption(GRAKN_URI)) ? arguments.getOptionValue(GRAKN_URI) : DEFAULT_GRAKN_URI;
-
-        this.executionName = (arguments.hasOption(EXECUTION_NAME_ARGUMENT)) ? arguments.getOptionValue(EXECUTION_NAME_ARGUMENT) : "";
 
         // If --no-data-generation is specified, don't generate any data (work with existing keyspace)
         this.generateData = !(arguments.hasOption(NO_DATA_GENERATION_ARGUMENT));

--- a/runner/src/util/BenchmarkConfigurationFile.java
+++ b/runner/src/util/BenchmarkConfigurationFile.java
@@ -26,17 +26,17 @@ import java.util.List;
  */
 
 public class BenchmarkConfigurationFile {
-    private String name;
+    private String graphName;
     private String schema;
     private String queries;
     private List<Integer> scalesToProfile;
     private Integer repeatsPerQuery;
 
-    public void setName(String name) {
-        this.name = name;
+    public void setGraphName(String graphName) {
+        this.graphName = graphName;
     }
-    public String getName() {
-        return this.name;
+    public String getGraphName() {
+        return this.graphName;
     }
 
     public void setSchema(String schemaFile) {

--- a/runner/test/GraknBenchmarkTest.java
+++ b/runner/test/GraknBenchmarkTest.java
@@ -23,14 +23,14 @@ public class GraknBenchmarkTest {
 
     @Test
     public void whenProvidingAbsolutePathToExistingConfig_benchmarkShouldStart() {
-        String[] args = new String[]{"--config", WEB_CONTENT_CONFIG_PATH.toAbsolutePath().toString()};
+        String[] args = new String[]{"--config", WEB_CONTENT_CONFIG_PATH.toAbsolutePath().toString(), "--execution-name", "grakn-benchmark-test"};
         CommandLine commandLine = BenchmarkArguments.parse(args);
         GraknBenchmark graknBenchmark = new GraknBenchmark(commandLine);
     }
 
     @Test
     public void whenProvidingRelativePathToExistingConfig_benchmarkShouldStart() {
-        String[] args = new String[]{"--config", "web_content_config_test.yml"};
+        String[] args = new String[]{"--config", "web_content_config_test.yml", "--execution-name", "grakn-benchmark-test"};
         System.setProperty("working.dir", WEB_CONTENT_CONFIG_PATH.getParent().toString());
         CommandLine commandLine = BenchmarkArguments.parse(args);
         GraknBenchmark graknBenchmark = new GraknBenchmark(commandLine);
@@ -38,7 +38,7 @@ public class GraknBenchmarkTest {
 
     @Test
     public void whenProvidingAbsolutePathToNonExistingConfig_throwException() {
-        String[] args = new String[]{"--config", "nonexistingpath"};
+        String[] args = new String[]{"--config", "nonexistingpath", "--execution-name", "grakn-benchmark-test"};
         CommandLine commandLine = BenchmarkArguments.parse(args);
         expectedException.expect(BootupException.class);
         expectedException.expectMessage("The provided config file [nonexistingpath] does not exist");
@@ -49,6 +49,13 @@ public class GraknBenchmarkTest {
     public void whenConfigurationArgumentNotProvided_throwException() {
         expectedException.expect(BootupException.class);
         expectedException.expectMessage("Missing required option: c");
-        GraknBenchmark graknBenchmark = new GraknBenchmark(BenchmarkArguments.parse(new String[] {}));
+        GraknBenchmark graknBenchmark = new GraknBenchmark(BenchmarkArguments.parse(new String[] {"--execution-name", "grakn-benchmark-test"}));
+    }
+
+    @Test
+    public void whenExecutionNameArgumentNotProvided_throwException() {
+        expectedException.expect(BootupException.class);
+        expectedException.expectMessage("Missing required option: n");
+        GraknBenchmark graknBenchmark = new GraknBenchmark(BenchmarkArguments.parse(new String[] {"--config", "web_content_config_test.yml"}));
     }
 }

--- a/runner/test/resources/web_content/web_content_config_test.yml
+++ b/runner/test/resources/web_content/web_content_config_test.yml
@@ -1,4 +1,4 @@
-name: "web_content"
+graphName: "web_content"
 schema: "web_content_schema.gql"
 queries: "queries.yml"
 scales:


### PR DESCRIPTION
Completes #116 and #115 

1. Renames remaining occurences of `benchmarking` (mostly for ES indexes) to `benchmark` for consistency
2. `--execution-name` is now a mandatory parameter for benchmark; this value is passed into elasticsearch. Before, it was being generated independently within benchmark and outside in the benchmark service server which could easily lead to errors.
3. rename `name` to `graphName` in the config files. The graph name is then also passed through into the root level `batchSpan` in zipkin.
4. Remove `batch-query` container within which queries were repeated as `AAA`, `BBB`. Now we just have root span `query` which all the tags that used to be on the batchSpan (eg. `scale`, `graphName`, `executionName`, `queryRepetitions`, `repetition`), and queries are repeated as `ABC`, `ABC` instead.
