### PR TITLE
Simplify Index template for ES, delete empty folders from package and fix setup.sh

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -40,9 +40,5 @@ distribution(
         "@external-dependencies-zipkin//file": "external-dependencies/zipkin.jar",
         "@external-dependencies-elasticsearch//file": "external-dependencies/elasticsearch.zip"
     },
-    empty_directories = [
-        "data/logs",
-        "data/data"
-    ],
     output_filename = "benchmark",
 )

--- a/runner/setup.sh
+++ b/runner/setup.sh
@@ -70,7 +70,7 @@ done
 echo
 
 echo -n "Starting Zipkin"
-ES_HOSTS=http://localhost:9200 env ES_INDEX="benchmark" java -jar $BENCHMARK_RUNNER_EXTERNAL_DEPS_DIR/zipkin.jar &
+ES_HOSTS=http://localhost:9200 env ES_INDEX="benchmark" STORAGE_TYPE=elasticsearch java -jar $BENCHMARK_RUNNER_EXTERNAL_DEPS_DIR/zipkin.jar &
 zipkin_pid=$!
 until $(curl --output /dev/null --silent --head --fail localhost:9411); do
   echo -n "."

--- a/runner/src/GraknBenchmark.java
+++ b/runner/src/GraknBenchmark.java
@@ -63,7 +63,7 @@ public class GraknBenchmark {
             // Parse the configuration for the benchmark
             CommandLine arguments = BenchmarkArguments.parse(args);
 
-            ElasticSearchManager.init(arguments);
+            ElasticSearchManager.putIndexTemplate(arguments);
             GraknBenchmark benchmark = new GraknBenchmark(arguments);
             benchmark.start();
         } catch (Exception e) {

--- a/runner/src/generator/DataGenerator.java
+++ b/runner/src/generator/DataGenerator.java
@@ -62,7 +62,6 @@ public class DataGenerator {
         this.iteration = 0;
         this.schemaDefinition = config.getGraqlSchema();
         initializeGeneration();
-        System.out.println(System.getProperty("user.dir"));
    }
 
     private void initializeGeneration() {

--- a/runner/src/util/ElasticSearchManager.java
+++ b/runner/src/util/ElasticSearchManager.java
@@ -1,117 +1,45 @@
 package grakn.benchmark.runner.util;
 
 import org.apache.commons.cli.CommandLine;
-import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.message.BasicHeader;
 import org.elasticsearch.client.Request;
-import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestClientBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
 import static grakn.benchmark.runner.util.BenchmarkArguments.ELASTIC_URI;
 
+/**
+ * Elastic Search manager used to override the default Zipkin index template which excludes the tags object.
+ * We need to include the tags object so that we can use it to retrieve spans relative to specific graphs
+ * or queries. Also we set the index template order to 10 to make sure it gets higher priority thant the zipkin defaults.
+ */
+
 public class ElasticSearchManager {
-    private static final Logger LOG = LoggerFactory.getLogger(ElasticSearchManager.class);
-    private static final String ES_SERVER_PROTOCOL = "http";
-    private static final String ES_SERVER_HOST = "localhost";
-    private static final int ES_SERVER_PORT = 9200;
+    private static final String DEFAULT_ES_SERVER_URI = "http://localhost:9200";
     private static final String ES_INDEX_TEMPLATE_NAME = "grakn-benchmark-index-template";
     private static final String INDEX_TEMPLATE =
-            "{"+
-                    "\"index_patterns\": [\"benchmarking:span-*\"],"+
-                    "\"settings\": {"+
-                    "    \"mapper\": {"+
-                    "        \"dynamic\": true"+
-                    "    }"+
-                    "},"+
-                    "\"mappings\": {"+
-                    "    \"_default_\": {"+
-                    "        \"dynamic_templates\": ["+
-                    "            {"+
-                    "              \"integers\": {"+
-                    "                \"match_mapping_type\": \"long\","+
-                    "                \"mapping\": {"+
-                    "                  \"type\": \"long\""+
-                    "                }"+
-                    "              }"+
-                    "            }"+
-                    "        ]"+
-                    "    },"+
-                    "    \"span\": {"+
-                    "        \"properties\": {"+
-                    "            \"tags.concepts\": {"+
-                    "                \"type\": \"long\""+
-                    "            },"+
-                    "            \"traceId\": {"+
-                    "                \"type\": \"keyword\", "+
-                    "                \"norms\": \"false\""+
-                    "            },"+
-                    "            \"name\": {"+
-                    "                \"type\": \"keyword\","+
-                    "                \"norms\": \"false\""+
-                    "            },"+
-                    "            \"annotations\": {"+
-                    "                \"type\": \"object\","+
-                    "                \"enabled\": \"true\""+
-                    "            },"+
-                    "            \"tags\": {"+
-                    "                \"enabled\": true,"+
-                    "                \"dynamic\": true,"+
-                    "                \"type\": \"object\""+
-                    "            }"+
-                    "        }"+
-                    "    }"+
-                    "}" +
-                    "}";
+            "{ \"order\" : 10,\n" +
+                    "  \"index_patterns\": [\"benchmark:span-*\"],\n" +
+                    "  \"mappings\": {\n" +
+                    "    \"span\": { \n" +
+                    "      \"properties\": {\n" +
+                    "        \"tags\": { \"enabled\": true }\n" +
+                    "}}}}";
 
-    private static void putIndexTemplate(RestClient esClient, String indexTemplateName, String indexTemplate) throws IOException {
-        Request putTemplateRequest = new Request("PUT", "/_template/" + indexTemplateName);
-        HttpEntity entity = new StringEntity(indexTemplate, ContentType.APPLICATION_JSON);
+    public static void putIndexTemplate(CommandLine arguments) throws IOException {
+        String serverURI =  (arguments.hasOption(ELASTIC_URI)) ? arguments.getOptionValue(ELASTIC_URI) : DEFAULT_ES_SERVER_URI;
+        RestClient restClient = RestClient.builder(HttpHost.create(serverURI)).build();
+
+        Request putTemplateRequest = new Request("PUT", "/_template/" + ES_INDEX_TEMPLATE_NAME);
+        HttpEntity entity = new StringEntity(INDEX_TEMPLATE, ContentType.APPLICATION_JSON);
         putTemplateRequest.setEntity(entity);
-        esClient.performRequest(putTemplateRequest);
-        LOG.debug("Created index template `" + indexTemplateName + "`");
-    }
 
-    private static boolean indexTemplateExists(RestClient esClient, String indexTemplateName) throws IOException {
-        try {
-            Request templateExistsRequest = new Request("GET", "/_template/" + indexTemplateName);
-            esClient.performRequest(templateExistsRequest);
-            LOG.debug("Index template `" + indexTemplateName + "` already exists");
-            return true;
-        } catch (ResponseException err) {
-            // 404 => template does not exist yet
-            LOG.debug("Index template `" + indexTemplateName + "` does not exist.");
-            return false;
-        }
-    }
-
-    public static void init(CommandLine arguments) throws IOException {
-        RestClientBuilder esRestClientBuilder;
-
-        if (arguments.hasOption(ELASTIC_URI)) {
-            String elasticUri = arguments.getOptionValue(ELASTIC_URI);
-            int splitIndex = elasticUri.lastIndexOf(":");
-            String esServerHost = elasticUri.substring(0, splitIndex);
-            Integer esServerPort = Integer.parseInt(elasticUri.substring(splitIndex+1));
-            esRestClientBuilder = RestClient.builder(new HttpHost(esServerHost, esServerPort, ES_SERVER_PROTOCOL));
-        } else {
-            esRestClientBuilder = RestClient.builder(new HttpHost(ES_SERVER_HOST, ES_SERVER_PORT, ES_SERVER_PROTOCOL));
-        }
-
-        esRestClientBuilder.setDefaultHeaders(new Header[]{new BasicHeader("header", "value")});
-        RestClient restClient = esRestClientBuilder.build();
-
-        if (!indexTemplateExists(restClient, ES_INDEX_TEMPLATE_NAME)) {
-            putIndexTemplate(restClient, ES_INDEX_TEMPLATE_NAME, INDEX_TEMPLATE);
-        }
+        restClient.performRequest(putTemplateRequest);
         restClient.close();
     }
+
 }

--- a/runner/src/util/ElasticSearchManager.java
+++ b/runner/src/util/ElasticSearchManager.java
@@ -26,6 +26,7 @@ public class ElasticSearchManager {
                     "  \"index_patterns\": [\"benchmark:span-*\"],\n" +
                     "  \"mappings\": {\n" +
                     "    \"span\": { \n" +
+                    "      \"_source\": {\"excludes\": [\"_q\"] },\n"+
                     "      \"properties\": {\n" +
                     "        \"tags\": { \"enabled\": true }\n" +
                     "}}}}";


### PR DESCRIPTION
Changes:

- Simplified index template in `ElasticsearchManager` to just override the `tags` object's `enabled`
- Made `ElastisearchManager` class smaller with some added comments
- Added `STORAGE_TYPE` to `setup.sh`, so that developers who rely on that script will have their spans stored in ES instead of having everything in Zipkin in-memory store 💃 
- Removed empty `data` folders when packaging Benchmark