### PR TITLE
New Benchmark Graphs - Social Network and Road Network (1/2)

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -27,12 +27,13 @@ distribution(
     },
     additional_files = {
         "//runner:benchmark": "benchmark",
-        "//runner:conf/societal_model/queries.yml": "conf/societal_model/queries.yml",
-        "//runner:conf/societal_model/societal_config_1.yml": "conf/societal_model/societal_config_1.yml",
-        "//runner:conf/societal_model/societal_model.gql": "conf/societal_model/societal_model.gql",
-        "//runner:conf/web_content/queries.yml": "conf/web_content/queries.yml",
-        "//runner:conf/web_content/web_content_config.yml": "conf/web_content/web_content_config.yml",
-        "//runner:conf/web_content/web_content_schema.gql": "conf/web_content/web_content_schema.gql",
+        "//runner:conf/road_network/queries.yml": "conf/road_network/queries.yml",
+        "//runner:conf/road_network/road_config.yml": "conf/road_network/road_config.yml",
+        "//runner:conf/road_network/road_network.gql": "conf/road_network/road_network_schema.gql",
+
+        "//runner:conf/road_network/queries.yml": "conf/road_network/queries.yml",
+        "//runner:conf/road_network/road_config.yml": "conf/road_network/road_config.yml",
+        "//runner:conf/road_network/road_network.gql": "conf/road_network/road_network_schema.gql",
         "//runner:logback": "conf/logback.xml",
         
         # External dependencies: Elasticsearch and Zipkin

--- a/BUILD
+++ b/BUILD
@@ -29,13 +29,13 @@ distribution(
         "//runner:benchmark": "benchmark",
         "//runner:conf/road_network/queries.yml": "conf/road_network/queries.yml",
         "//runner:conf/road_network/road_config.yml": "conf/road_network/road_config.yml",
-        "//runner:conf/road_network/road_network.gql": "conf/road_network/road_network_schema.gql",
+        "//runner:conf/road_network/road_network.gql": "conf/road_network/road_network.gql",
 
-        "//runner:conf/road_network/queries.yml": "conf/road_network/queries.yml",
-        "//runner:conf/road_network/road_config.yml": "conf/road_network/road_config.yml",
-        "//runner:conf/road_network/road_network.gql": "conf/road_network/road_network_schema.gql",
+        "//runner:conf/social_network/queries.yml": "conf/social_network/queries.yml",
+        "//runner:conf/social_network/social_network_config.yml": "conf/social_network/social_network_config.yml",
+        "//runner:conf/social_network/social_network.gql": "conf/social_network/social_network.gql",
         "//runner:logback": "conf/logback.xml",
-        
+
         # External dependencies: Elasticsearch and Zipkin
         "//runner:setup.sh": "external-dependencies/setup.sh",
         "@external-dependencies-zipkin//file": "external-dependencies/zipkin.jar",

--- a/runner/conf/biochem_network/biochem_config.yml
+++ b/runner/conf/biochem_network/biochem_config.yml
@@ -1,0 +1,11 @@
+graphName: "biochem_network"
+schema: "biochem_network.gql"
+queries: "queries.yml"
+scales:
+- 500
+repeatsPerQuery: 1
+  # TODO
+  # concurrency:
+  #   clients: 1
+# mixed:
+# replication: 1

--- a/runner/conf/biochem_network/biological_network.gql
+++ b/runner/conf/biochem_network/biological_network.gql
@@ -1,0 +1,19 @@
+define
+
+    # fixed increments
+    name sub attribute datatype string;
+
+    # fixed increments
+    chemical sub entity,
+        plays agent,
+        has name; # append uniquely (1 name per chemical)
+
+    # fixed increments
+    enzyme sub entity,
+        plays catalyst,
+        has name; # append unique (1 per enzyme)
+
+    # fixed increments
+    interaction sub relationship;
+        relates agent, # scale number of agents over time
+        relates catalyst; # scale number of catalysts over time

--- a/runner/conf/biochem_network/queries.yml
+++ b/runner/conf/biochem_network/queries.yml
@@ -1,5 +1,5 @@
 queries:
   - "match $x isa enzyme; get;"
-  - "match $x has $n; $n isa name; get;"    # expect to see scale in out degree of name and number of names
-  - "match $r (agent: $agent); get $agent;" # expect to see scale in role players * number of relationships
+  - "match $x has $n; $n isa name; get;"
+  - "match $r (agent: $agent); get $agent;"
 

--- a/runner/conf/biochem_network/queries.yml
+++ b/runner/conf/biochem_network/queries.yml
@@ -1,5 +1,5 @@
 queries:
-  - match $x isa enzyme; get;
-  - match $x has $n; $n isa name; get;    # expect to see scale in out degree of name and number of names
-  - match $r (agent: $agent); get $agent; # expect to see scale in role players * number of relationships
+  - "match $x isa enzyme; get;"
+  - "match $x has $n; $n isa name; get;"    # expect to see scale in out degree of name and number of names
+  - "match $r (agent: $agent); get $agent;" # expect to see scale in role players * number of relationships
 

--- a/runner/conf/biochem_network/queries.yml
+++ b/runner/conf/biochem_network/queries.yml
@@ -1,0 +1,5 @@
+queries:
+  - match $x isa enzyme; get;
+  - match $x has $n; $n isa name; get;    # expect to see scale in out degree of name and number of names
+  - match $r (agent: $agent); get $agent; # expect to see scale in role players * number of relationships
+

--- a/runner/conf/financial_transactions/financial.gql
+++ b/runner/conf/financial_transactions/financial.gql
@@ -1,0 +1,31 @@
+define
+
+    # fixed increments
+    quantity sub attribute datatype long;
+    #name sub attribute datatype string;
+
+    # don't instantiate this
+    trader sub entity,
+        plays transactor,
+        has name;
+
+    # scaling increments => graph dominated by entities
+    company sub trader;
+    # scaling increments => graph dominated by entities
+    person sub trader;
+
+    #government sub entity,
+    #    plays taxor,
+    #    has name;
+
+
+    # fixed increments
+    transaction sub relationship,
+        relates transactor; # scaling increments => most connections are via role players to few relationships
+    #    plays taxed;
+
+
+    #taxation sub relationship,
+    #    relates taxor,
+    #    relatex taxed;
+

--- a/runner/conf/financial_transactions/financial_config.yml
+++ b/runner/conf/financial_transactions/financial_config.yml
@@ -1,0 +1,11 @@
+graphName: "financial"
+schema: "financial.gql"
+queries: "queries.yml"
+scales:
+- 500
+repeatsPerQuery: 1
+  # TODO
+  # concurrency:
+  #   clients: 1
+# mixed:
+# replication: 1

--- a/runner/conf/financial_transactions/queries.yml
+++ b/runner/conf/financial_transactions/queries.yml
@@ -1,6 +1,6 @@
 queries:
-  - match $x isa trader; get;             # expect to see this scale in the square of the number of relationships
+  - "match $x isa trader; get;"             # expect to see this scale in the square of the number of relationships
   # expect to see scale in out degree of name * number of name assuming QP starts at `name` label
-  - match $x has $n; $n isa name; get;
-  - match $r (agent: $agent); $r isa transaction; get $agent; # expect to see scale in role players * number of relationships
+  - "match $x has $n; $n isa name; get;"
+  - "match $r (agent: $agent); $r isa transaction; get $agent;" # expect to see scale in role players * number of relationships
 

--- a/runner/conf/financial_transactions/queries.yml
+++ b/runner/conf/financial_transactions/queries.yml
@@ -1,0 +1,6 @@
+queries:
+  - match $x isa trader; get;             # expect to see this scale in the square of the number of relationships
+  # expect to see scale in out degree of name * number of name assuming QP starts at `name` label
+  - match $x has $n; $n isa name; get;
+  - match $r (agent: $agent); $r isa transaction; get $agent; # expect to see scale in role players * number of relationships
+

--- a/runner/conf/financial_transactions/queries.yml
+++ b/runner/conf/financial_transactions/queries.yml
@@ -1,6 +1,7 @@
 queries:
-  - "match $x isa trader; get;"             # expect to see this scale in the square of the number of relationships
+  - "match $x isa trader; get;"
   # expect to see scale in out degree of name * number of name assuming QP starts at `name` label
   - "match $x has $n; $n isa name; get;"
-  - "match $r (agent: $agent); $r isa transaction; get $agent;" # expect to see scale in role players * number of relationships
+  # expect to see scale in role players * number of relationships
+  - "match $r (agent: $agent); $r isa transaction; get $agent;"
 

--- a/runner/conf/road_network/queries.yml
+++ b/runner/conf/road_network/queries.yml
@@ -1,7 +1,7 @@
-queries.yml
+queries:
   # expect to see this scale linearly with scale
   - "match $x isa road; get;"
   # expect to see scale in out degree of name (increasing increments) and number of names (fixed increments)
-  - "match $x has $n; $n isa name; get;"
+  - "match $x has name $n; get;"
   # expect to see scale in role player (upper bounded) * number of relationships (fixed increments)
-  - "match $r (agent: $endpoint); get $endpoint;"
+  - "match $r (endpoint: $endpoint); get $endpoint;"

--- a/runner/conf/road_network/queries.yml
+++ b/runner/conf/road_network/queries.yml
@@ -1,7 +1,7 @@
 queries.yml
   # expect to see this scale linearly with scale
-  - match $x isa road; get;
+  - "match $x isa road; get;"
   # expect to see scale in out degree of name (increasing increments) and number of names (fixed increments)
-  - match $x has $n; $n isa name; get;
+  - "match $x has $n; $n isa name; get;"
   # expect to see scale in role player (upper bounded) * number of relationships (fixed increments)
-  - match $r (agent: $endpoint); get $endpoint;
+  - "match $r (agent: $endpoint); get $endpoint;"

--- a/runner/conf/road_network/queries.yml
+++ b/runner/conf/road_network/queries.yml
@@ -1,0 +1,7 @@
+queries.yml
+  # expect to see this scale linearly with scale
+  - match $x isa road; get;
+  # expect to see scale in out degree of name (increasing increments) and number of names (fixed increments)
+  - match $x has $n; $n isa name; get;
+  # expect to see scale in role player (upper bounded) * number of relationships (fixed increments)
+  - match $r (agent: $endpoint); get $endpoint;

--- a/runner/conf/road_network/road_config.yml
+++ b/runner/conf/road_network/road_config.yml
@@ -1,0 +1,11 @@
+graphName: "road_network"
+schema: "road_network.gql"
+queries: "queries.yml"
+scales:
+- 500
+repeatsPerQuery: 1
+  # TODO
+  # concurrency:
+  #   clients: 1
+# mixed:
+# replication: 1

--- a/runner/conf/road_network/road_network.gql
+++ b/runner/conf/road_network/road_network.gql
@@ -1,0 +1,14 @@
+define
+
+    # fixed increments
+    name sub attribute datatype string;
+    # region-code sub attribute datatype long;
+
+    # fixed increments
+    road sub entity,
+        plays endpoint,
+        has name; # fixed number of names per road
+
+    # fixed increments
+    intersection sub relationship,
+        relates endpoint; # fixed upper bound on RPs

--- a/runner/conf/social_network/queries.yml
+++ b/runner/conf/social_network/queries.yml
@@ -1,8 +1,4 @@
 queries:
-  # expect to see this scale with entities (fixed increments)
-  - match $x isa person; get;
-
-  #
-  - match $x has name $n; $n isa name; get;
-
-  - match $r (friend: $f); $f isa person; get;
+  - "match $x isa person; get;"
+  - "match $x has name $n; $n isa name; get;"
+  - "match $r (friend: $f); $f isa person; get;"

--- a/runner/conf/social_network/queries.yml
+++ b/runner/conf/social_network/queries.yml
@@ -1,0 +1,8 @@
+queries:
+  # expect to see this scale with entities (fixed increments)
+  - match $x isa person; get;
+
+  #
+  - match $x has name $n; $n isa name; get;
+
+  - match $r (friend: $f); $f isa person; get;

--- a/runner/conf/social_network/social_network.gql
+++ b/runner/conf/social_network/social_network.gql
@@ -1,0 +1,23 @@
+define
+
+    # fixed increments
+    name sub attribute datatype string;
+
+    # fixed increments
+    person sub entity,
+        plays friend
+        plays liker,
+        has name; # increasing number of names
+
+    # fixed increments
+    page sub entity,
+        plays liked;
+
+    # scaling increments
+    friendship sub relationship,
+        relates friend; # 2 friends in a friendship only
+
+    # scaling increments
+    like sub relationship,
+        relates liked, # only 1 liked per like
+        relates liker; # only 1 liker per like

--- a/runner/conf/social_network/social_network.gql
+++ b/runner/conf/social_network/social_network.gql
@@ -7,7 +7,7 @@ define
     person sub entity,
         plays friend
         plays liker,
-        has name; # increasing number of names
+        has name; # increasing number of names added each iter - people will have many names
 
     # fixed increments
     page sub entity,

--- a/runner/conf/social_network/social_network_config.yml
+++ b/runner/conf/social_network/social_network_config.yml
@@ -1,0 +1,11 @@
+graphName: "social_network"
+schema: "social_network.gql"
+queries: "queries.yml"
+scales:
+- 500
+repeatsPerQuery: 1
+  # TODO
+  # concurrency:
+  #   clients: 1
+# mixed:
+# replication: 1

--- a/runner/src/GraknBenchmark.java
+++ b/runner/src/GraknBenchmark.java
@@ -35,10 +35,6 @@ import org.apache.ignite.logger.slf4j.Slf4jLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 
 /**

--- a/runner/src/generator/DataGenerator.java
+++ b/runner/src/generator/DataGenerator.java
@@ -74,7 +74,6 @@ public class DataGenerator {
             HashSet<EntityType> entityTypes = SchemaManager.getTypesOfMetaType(tx, "entity");
             HashSet<RelationshipType> relationshipTypes = SchemaManager.getTypesOfMetaType(tx, "relationship");
             HashSet<AttributeType> attributeTypes = SchemaManager.getTypesOfMetaType(tx, "attribute");
-
             LOG.info("Initialising ignite...");
             this.storage = new IgniteConceptIdStore(entityTypes, relationshipTypes, attributeTypes);
         }

--- a/runner/src/generator/DataGenerator.java
+++ b/runner/src/generator/DataGenerator.java
@@ -92,7 +92,6 @@ public class DataGenerator {
         int graphScale = dataStrategies.getGraphScale();
 
         while (graphScale < graphScaleLimit) {
-            graphScale = dataStrategies.getGraphScale();
             try (Grakn.Transaction tx = session.transaction(GraknTxType.WRITE)) {
                 TypeStrategyInterface typeStrategy = operationStrategies.next().next();
                 GeneratorInterface generator = gf.create(typeStrategy, tx); // TODO Can we do without creating a new generator each iteration
@@ -105,7 +104,7 @@ public class DataGenerator {
                 iteration++;
 
                 printProgress(graphScale, typeStrategy.getTypeLabel());
-
+                graphScale = dataStrategies.getGraphScale();
                 tx.commit();
             }
         }

--- a/runner/src/pick/CentralStreamProvider.java
+++ b/runner/src/pick/CentralStreamProvider.java
@@ -22,20 +22,37 @@ import grakn.core.client.Grakn;
 import grakn.benchmark.runner.probdensity.ProbabilityDensityFunction;
 
 import java.util.ArrayList;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
+ *
+ * This is a highly flexible StreamProvider. The idea of a _central_ stream is that one or several concepts
+ * will be the center of many relationships added (ie. imagine this as a _repeated concept provider_)
+ *
+ * It can be specified with two PDFs:
+ * The one used to construct specifies how many _central_ concepts will be provided. For example,
+ * when adding multiple relationships, if the centralConceptsPdf specifies `1`, all relationships
+ * will connect to that same Concept.
+ *
+ * The second PDF specifies how many of these central items to withdraw in a stream this iteration.
+ * The specific values are chosen from the list of central concepts as a circular buffer from the last
+ * index that hasn't been used.
+ *
  * @param <T>
  */
 public class CentralStreamProvider<T> implements StreamProviderInterface<T> {
     StreamInterface<T> streamer;
     private Boolean isReset;
     private ArrayList<T> conceptIdList;
+    private int consumeFrom = 0;
+    private ProbabilityDensityFunction centralConceptsPdf;
 
-    public CentralStreamProvider(StreamInterface<T> streamer) {
+    public CentralStreamProvider(ProbabilityDensityFunction centralConceptsPdf, StreamInterface<T> streamer) {
         this.streamer = streamer;
         this.isReset = true;
         this.conceptIdList = new ArrayList<>();
+        this.centralConceptsPdf = centralConceptsPdf;
     }
 
     @Override
@@ -48,26 +65,37 @@ public class CentralStreamProvider<T> implements StreamProviderInterface<T> {
         // Get the same list as used previously, or generate one if not seen before
         // Only create a new stream if reset() has been called prior
 
-        int streamLength = pdf.sample();
         if (this.isReset) {
+            // re-fill the internal buffer of conceptIds to be repeated (the centrality aspect)
+            int quantity = this.centralConceptsPdf.sample();
 
-            // TODO remove this hack when we have negation
             if (this.streamer instanceof NotInRelationshipConceptIdStream) {
-                ((NotInRelationshipConceptIdStream)this.streamer).setRequiredLength(streamLength);
+                ((NotInRelationshipConceptIdStream)this.streamer).setRequiredLength(quantity);
             }
 
-            // don't bother with checking if the stream is long enough here, might just return a reduced length...
-            Stream<T> stream = this.streamer.getStream(tx);
-
-            //Read stream to list and store to be used again later
             this.conceptIdList.clear();
+            this.streamer.getStream(tx).limit(quantity).forEach(conceptId -> conceptIdList.add(conceptId));
 
-            stream.limit(streamLength).forEach(conceptId -> this.conceptIdList.add(conceptId));
-
+            this.consumeFrom = 0;
             this.isReset = false;
         }
-        // Return the same stream as before
-        return this.conceptIdList.stream();
+
+        if (this.conceptIdList.size() == 0) {
+            return Stream.empty();
+        } else {
+
+            // construct the circular buffer-reading stream
+
+            // number of items to read, which if longer than the length of the IDs list will wrap
+            int streamLength = pdf.sample();
+            int startIndex = consumeFrom;
+            int endIndex = startIndex + streamLength;
+            this.consumeFrom = (endIndex) % this.conceptIdList.size();
+
+            // feed the conceptIdList as a circular buffer
+            return IntStream.range(startIndex, endIndex)
+                    .mapToObj(index -> conceptIdList.get(index % conceptIdList.size()));
+        }
     }
 }
 

--- a/runner/src/schemaspecific/RoadNetworkGenerator.java
+++ b/runner/src/schemaspecific/RoadNetworkGenerator.java
@@ -1,0 +1,177 @@
+package grakn.benchmark.runner.schemaspecific;
+
+import grakn.benchmark.runner.pick.CentralStreamProvider;
+import grakn.benchmark.runner.pick.StreamProvider;
+import grakn.benchmark.runner.pick.StringStreamGenerator;
+import grakn.benchmark.runner.probdensity.*;
+import grakn.benchmark.runner.storage.ConceptStore;
+import grakn.benchmark.runner.storage.FromIdStorageConceptIdPicker;
+import grakn.benchmark.runner.storage.IdStoreInterface;
+import grakn.benchmark.runner.storage.NotInRelationshipConceptIdPicker;
+import grakn.benchmark.runner.strategy.*;
+import grakn.core.concept.ConceptId;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Random;
+
+public class RoadNetworkGenerator implements SchemaSpecificDataGenerator {
+
+    private Random random;
+    private ConceptStore storage;
+
+    private RouletteWheel<TypeStrategyInterface> entityStrategies;
+    private RouletteWheel<TypeStrategyInterface> relationshipStrategies;
+    private RouletteWheel<TypeStrategyInterface> attributeStrategies;
+    private RouletteWheel<RouletteWheel<TypeStrategyInterface>> operationStrategies;
+
+    public RoadNetworkGenerator(Random random, ConceptStore storage) {
+        this.random = random;
+        this.storage = storage;
+
+        this.entityStrategies = new RouletteWheel<>(random);
+        this.relationshipStrategies = new RouletteWheel<>(random);
+        this.attributeStrategies = new RouletteWheel<>(random);
+        this.operationStrategies = new RouletteWheel<>(random);
+
+        buildGenerator();
+    }
+
+    private void buildGenerator() {
+        buildStrategies();
+        this.operationStrategies.add(1.0, entityStrategies);
+        this.operationStrategies.add(1.2, relationshipStrategies);
+        this.operationStrategies.add(0.4, attributeStrategies);
+    }
+
+    private void buildStrategies() {
+
+        /*
+        Entities
+         */
+
+        this.entityStrategies.add(
+                1.0,
+                new EntityStrategy(
+                        "road",
+                        new FixedUniform(this.random, 10, 40))
+        );
+
+        /*
+        Attributes
+         */
+
+        StringStreamGenerator nameStream = new StringStreamGenerator(random, 6);
+
+        this.attributeStrategies.add(
+                1.0,
+                new AttributeStrategy<>(
+                        "name",
+                        new FixedUniform(this.random,3, 7),
+                        new StreamProvider<>(nameStream)
+                )
+        );
+
+
+        /*
+        Relationships
+         */
+
+
+        // intersection
+        // TODO what we want here is to repeat 5-10 roads not initially in a relationship
+        // and use these to connect to to some number of other roads via intersections
+        // ie. repeat those 5-10 roads that were initially not in a relationship until number of
+        // relationships created is exhausted
+
+        // TODO
+
+//        RolePlayerTypeStrategy unusedEndpointRoads = new RolePlayerTypeStrategy(
+//                "endpoint",
+//                "road",
+//                new FixedConstant(1),
+//                new CentralStreamProvider<>(
+//                    new NotInRelationshipConceptIdPicker(
+//                            random,
+//                            (IdStoreInterface) storage,
+//                           "road",
+//                           "intersection",
+//                           "endpoint"
+//                    )
+//                )
+//        );
+//        RolePlayerTypeStrategy anyEndpointRoads = new RolePlayerTypeStrategy(
+//                "endpoint",
+//                "road",
+//                new FixedUniform(random, 1, 5),
+//                new StreamProvider<>(
+//                        new FromIdStorageConceptIdPicker(random, (IdStoreInterface) storage, "road")
+//                )
+//        );
+//
+//        this.relationshipStrategies.add(
+//                1.0,
+//                new RelationshipStrategy(
+//                        "intersection",
+//                        new Fixed
+//                        new HashSet<>(Arrays.asList(friendRoleFiller))
+//                )
+//        );
+
+
+        // like
+        RolePlayerTypeStrategy likedPageRole = new RolePlayerTypeStrategy(
+                "liked",
+                "page",
+                new FixedConstant(1),
+                new StreamProvider<>(new FromIdStorageConceptIdPicker(random, (IdStoreInterface) storage, "page"))
+        );
+        RolePlayerTypeStrategy likerPersonRole = new RolePlayerTypeStrategy(
+                "liker",
+                "person",
+                new FixedConstant(1),
+                new StreamProvider<>(new FromIdStorageConceptIdPicker(random, (IdStoreInterface) storage, "person"))
+        );
+        this.relationshipStrategies.add(
+                1.0,
+                new RelationshipStrategy(
+                        "like",
+                        new ScalingDiscreteGaussian(random, () -> this.getGraphScale(), 0.05, 0.001),
+                        new HashSet<>(Arrays.asList(likedPageRole, likerPersonRole))
+                )
+        );
+
+
+        // @has-name
+        RolePlayerTypeStrategy nameOwner = new RolePlayerTypeStrategy(
+                "@has-name-owner",
+                "person",
+                new FixedConstant(1),
+                new StreamProvider<>(new FromIdStorageConceptIdPicker(random, (IdStoreInterface) storage, "person"))
+        );
+        RolePlayerTypeStrategy nameValue = new RolePlayerTypeStrategy(
+                "@has-name-value",
+                "name",
+                new FixedConstant(1),
+                new StreamProvider<>(new FromIdStorageConceptIdPicker(random, (IdStoreInterface) storage, "name"))
+        );
+        this.relationshipStrategies.add(
+                1.0,
+                new RelationshipStrategy(
+                        "@has-name",
+                        new ScalingDiscreteGaussian(random, () -> this.getGraphScale(), 0.1, 0.03),
+                        new HashSet<>(Arrays.asList(nameOwner, nameValue))
+                )
+        );
+    }
+
+    @Override
+    public RouletteWheel<RouletteWheel<TypeStrategyInterface>> getStrategy() {
+        return this.operationStrategies;
+    }
+
+    @Override
+    public ConceptStore getConceptStore() {
+        return this.storage;
+    }
+}

--- a/runner/src/schemaspecific/SchemaSpecificDataGeneratorFactory.java
+++ b/runner/src/schemaspecific/SchemaSpecificDataGeneratorFactory.java
@@ -14,6 +14,8 @@ public class SchemaSpecificDataGeneratorFactory {
                 return new SocietalModelGenerator(random, storage);
             case "social_network":
                 return new SocialNetworkGenerator(random, storage);
+            case "road_network":
+                return new RoadNetworkGenerator(random, storage);
 //            case "societal_model":
 //                return new SocietalModelGenerator(random, storage);
 //            case "societal_model":

--- a/runner/src/schemaspecific/SchemaSpecificDataGeneratorFactory.java
+++ b/runner/src/schemaspecific/SchemaSpecificDataGeneratorFactory.java
@@ -12,6 +12,14 @@ public class SchemaSpecificDataGeneratorFactory {
                 return new WebContentGenerator(random, storage);
             case "societal_model":
                 return new SocietalModelGenerator(random, storage);
+            case "social_network":
+                return new SocialNetworkGenerator(random, storage);
+//            case "societal_model":
+//                return new SocietalModelGenerator(random, storage);
+//            case "societal_model":
+//                return new SocietalModelGenerator(random, storage);
+//            case "societal_model":
+//                return new SocietalModelGenerator(random, storage);
             default:
                 throw new RuntimeException("Unknown specific schema generation strategy name: " + name);
         }

--- a/runner/src/schemaspecific/SocialNetworkGenerator.java
+++ b/runner/src/schemaspecific/SocialNetworkGenerator.java
@@ -149,7 +149,7 @@ public class SocialNetworkGenerator implements SchemaSpecificDataGenerator {
                 1.0,
                 new RelationshipStrategy(
                         "@has-name",
-                        new ScalingDiscreteGaussian(random, () -> this.getGraphScale(), 0.05, 0.001),
+                        new ScalingDiscreteGaussian(random, () -> this.getGraphScale(), 0.1, 0.03),
                         new HashSet<>(Arrays.asList(nameOwner, nameValue))
                 )
         );

--- a/runner/src/schemaspecific/SocialNetworkGenerator.java
+++ b/runner/src/schemaspecific/SocialNetworkGenerator.java
@@ -1,0 +1,167 @@
+package grakn.benchmark.runner.schemaspecific;
+
+import grakn.benchmark.runner.pick.StreamProvider;
+import grakn.benchmark.runner.pick.StringStreamGenerator;
+import grakn.benchmark.runner.probdensity.FixedConstant;
+import grakn.benchmark.runner.probdensity.FixedDiscreteGaussian;
+import grakn.benchmark.runner.probdensity.ScalingBoundedZipf;
+import grakn.benchmark.runner.probdensity.ScalingDiscreteGaussian;
+import grakn.benchmark.runner.storage.ConceptStore;
+import grakn.benchmark.runner.storage.FromIdStorageConceptIdPicker;
+import grakn.benchmark.runner.storage.IdStoreInterface;
+import grakn.benchmark.runner.strategy.*;
+import org.apache.ignite.IgniteDataStreamer;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Random;
+
+public class SocialNetworkGenerator implements SchemaSpecificDataGenerator {
+
+    private Random random;
+    private ConceptStore storage;
+
+    private RouletteWheel<TypeStrategyInterface> entityStrategies;
+    private RouletteWheel<TypeStrategyInterface> relationshipStrategies;
+    private RouletteWheel<TypeStrategyInterface> attributeStrategies;
+    private RouletteWheel<RouletteWheel<TypeStrategyInterface>> operationStrategies;
+
+    public SocialNetworkGenerator(Random random, ConceptStore storage) {
+        this.random = random;
+        this.storage = storage;
+
+        this.entityStrategies = new RouletteWheel<>(random);
+        this.relationshipStrategies = new RouletteWheel<>(random);
+        this.attributeStrategies = new RouletteWheel<>(random);
+        this.operationStrategies = new RouletteWheel<>(random);
+
+        buildGenerator();
+    }
+
+    private void buildGenerator() {
+        buildStrategies();
+        this.operationStrategies.add(1.0, entityStrategies);
+        this.operationStrategies.add(1.2, relationshipStrategies);
+        this.operationStrategies.add(0.4, attributeStrategies);
+    }
+
+    private void buildStrategies() {
+
+        /*
+        Entities
+         */
+
+        this.entityStrategies.add(
+                1.0,
+                new EntityStrategy(
+                        "person",
+                        new FixedDiscreteGaussian(this.random, 30, 10))
+        );
+
+        this.entityStrategies.add(
+                1.0,
+                new EntityStrategy(
+                        "page",
+                        new FixedDiscreteGaussian(this.random, 5, 1)
+                )
+        );
+
+        /*
+        Attributes
+         */
+
+        StringStreamGenerator nameStream = new StringStreamGenerator(random, 6);
+
+        this.attributeStrategies.add(
+                1.0,
+                new AttributeStrategy<>(
+                        "name",
+                        new FixedDiscreteGaussian(this.random,20, 7),
+                        new StreamProvider<>(nameStream)
+                )
+        );
+
+
+        /*
+        Relationships
+         */
+
+
+        // friendship
+        RolePlayerTypeStrategy friendRoleFiller = new RolePlayerTypeStrategy(
+                "friend",
+                "person",
+                new FixedConstant(2),
+                new StreamProvider<>(
+                    new FromIdStorageConceptIdPicker(
+                        random,
+                        (IdStoreInterface) this.storage,
+                        "person")
+                )
+        );
+        this.relationshipStrategies.add(
+                1.0,
+                new RelationshipStrategy(
+                        "friendship",
+                        new ScalingBoundedZipf(this.random, ()->this.getGraphScale(), 0.5, 2.5),
+                        new HashSet<>(Arrays.asList(friendRoleFiller))
+                )
+        );
+
+
+        // like
+        RolePlayerTypeStrategy likedPageRole = new RolePlayerTypeStrategy(
+                "liked",
+                "page",
+                new FixedConstant(1),
+                new StreamProvider<>(new FromIdStorageConceptIdPicker(random, (IdStoreInterface) storage, "page"))
+        );
+        RolePlayerTypeStrategy likerPersonRole = new RolePlayerTypeStrategy(
+                "liker",
+                "person",
+                new FixedConstant(1),
+                new StreamProvider<>(new FromIdStorageConceptIdPicker(random, (IdStoreInterface) storage, "person"))
+        );
+        this.relationshipStrategies.add(
+                1.0,
+                new RelationshipStrategy(
+                        "like",
+                        new ScalingDiscreteGaussian(random, () -> this.getGraphScale(), 0.05, 0.001),
+                        new HashSet<>(Arrays.asList(likedPageRole, likerPersonRole))
+                )
+        );
+
+
+        // @has-name
+        RolePlayerTypeStrategy nameOwner = new RolePlayerTypeStrategy(
+                "@has-name-owner",
+                "person",
+                new FixedConstant(1),
+                new StreamProvider<>(new FromIdStorageConceptIdPicker(random, (IdStoreInterface) storage, "person"))
+        );
+        RolePlayerTypeStrategy nameValue = new RolePlayerTypeStrategy(
+                "@has-name-value",
+                "name",
+                new FixedConstant(1),
+                new StreamProvider<>(new FromIdStorageConceptIdPicker(random, (IdStoreInterface) storage, "name"))
+        );
+        this.relationshipStrategies.add(
+                1.0,
+                new RelationshipStrategy(
+                        "@has-name",
+                        new ScalingDiscreteGaussian(random, () -> this.getGraphScale(), 0.05, 0.001),
+                        new HashSet<>(Arrays.asList(nameOwner, nameValue))
+                )
+        );
+    }
+
+    @Override
+    public RouletteWheel<RouletteWheel<TypeStrategyInterface>> getStrategy() {
+        return this.operationStrategies;
+    }
+
+    @Override
+    public ConceptStore getConceptStore() {
+        return this.storage;
+    }
+}

--- a/runner/src/schemaspecific/SocietalModelGenerator.java
+++ b/runner/src/schemaspecific/SocietalModelGenerator.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
 
+@Deprecated
 public class SocietalModelGenerator implements SchemaSpecificDataGenerator {
 
     private Random random;

--- a/runner/src/schemaspecific/SocietalModelGenerator.java
+++ b/runner/src/schemaspecific/SocietalModelGenerator.java
@@ -88,6 +88,7 @@ public class SocietalModelGenerator implements SchemaSpecificDataGenerator {
                         "company",
                         new FixedConstant(1),
                         new CentralStreamProvider<>(
+                                new FixedConstant(1),
                                 new NotInRelationshipConceptIdStream(
                                         "employment",
                                         "employer",

--- a/runner/src/schemaspecific/WebContentGenerator.java
+++ b/runner/src/schemaspecific/WebContentGenerator.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
 
+@Deprecated
 public class WebContentGenerator implements SchemaSpecificDataGenerator {
 
     private Random random;

--- a/runner/src/schemaspecific/WebContentGenerator.java
+++ b/runner/src/schemaspecific/WebContentGenerator.java
@@ -141,6 +141,7 @@ public class WebContentGenerator implements SchemaSpecificDataGenerator {
                         "company",
                         fixedConstant(1),
                         new CentralStreamProvider<>(
+                                fixedConstant(1),
                                 notInRelationshipConceptIdStoragePicker(
                                         "company",
                                         "employment",
@@ -166,6 +167,7 @@ public class WebContentGenerator implements SchemaSpecificDataGenerator {
                         "university",
                         fixedConstant(1),
                         new CentralStreamProvider<>(
+                                fixedConstant(1),
                                 notInRelationshipConceptIdStoragePicker(
                                         "university",
                                         "employment",
@@ -190,7 +192,7 @@ public class WebContentGenerator implements SchemaSpecificDataGenerator {
                         "group_",
                         "project",
                         fixedConstant(1),
-                        new CentralStreamProvider<>(fromIdStorageConceptIdPicker("project"))
+                        new CentralStreamProvider<>(fixedConstant(1), fromIdStorageConceptIdPicker("project"))
                 )
         ));
 
@@ -209,7 +211,7 @@ public class WebContentGenerator implements SchemaSpecificDataGenerator {
                         "group_",
                         "team",
                         fixedConstant(1),
-                        new CentralStreamProvider<>(fromIdStorageConceptIdPicker("team"))
+                        new CentralStreamProvider<>(fixedConstant(1), fromIdStorageConceptIdPicker("team"))
                 )
         ));
 
@@ -276,7 +278,7 @@ public class WebContentGenerator implements SchemaSpecificDataGenerator {
                         "owner",
                         "department",
                         fixedConstant(1),  // pick 1 department for this n from fixedUniform(2,10)
-                        new CentralStreamProvider<>(fromIdStorageConceptIdPicker("department"))
+                        new CentralStreamProvider<>(fixedConstant(1),fromIdStorageConceptIdPicker("department"))
                 ),
                 rolePlayerTypeStrategy(
                         "property",

--- a/runner/src/storage/IgniteConceptIdStore.java
+++ b/runner/src/storage/IgniteConceptIdStore.java
@@ -45,13 +45,12 @@ import static grakn.core.concept.AttributeType.DataType.STRING;
 public class IgniteConceptIdStore implements IdStoreInterface {
     private static final Logger LOG = LoggerFactory.getLogger(IgniteConceptIdStore.class);
 
-    private final HashSet<String> entityTypeLabels;
-    private final HashSet<String> relationshipTypeLabels;
-    private final HashMap<java.lang.String, AttributeType.DataType<?>> attributeTypeLabels; // typeLabel, datatype
-    private HashMap<String, String> typeLabelsTotableNames = new HashMap<>();
+    private HashSet<String> entityTypeLabels;
+    private HashSet<String> relationshipTypeLabels;
+    private HashMap<java.lang.String, AttributeType.DataType<?>> attributeTypeLabels; // typeLabel, datatype
+    private HashMap<String, String> labelToSqlName;
 
     private Connection conn;
-    private HashSet<String> allTypeLabels;
     private final String cachingMethod = "REPLICATED";
     private final int ID_INDEX = 1;
     private final int VALUE_INDEX = 2;
@@ -72,59 +71,43 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                                 HashSet<RelationshipType> relationshipTypes,
                                 HashSet<AttributeType> attributeTypes) {
 
+        this.collectTypeLabels(entityTypes, relationshipTypes, attributeTypes);
+        labelToSqlName = this.mapLabelToSqlName(entityTypeLabels, relationshipTypeLabels, attributeTypeLabels.keySet());
+        this.cleanTables();
+        this.initializeSqlDriver();
+        this.createTables();
+    }
+
+    private void collectTypeLabels(Set<EntityType> entityTypes,
+                                   Set<RelationshipType> relationshipTypes,
+                                   Set<AttributeType> attributeTypes) {
         this.entityTypeLabels = this.getTypeLabels(entityTypes);
         this.relationshipTypeLabels = this.getTypeLabels(relationshipTypes);
         this.attributeTypeLabels = this.getAttributeTypeLabels(attributeTypes);
-
-
         // add @has-[attribute] relationships as possible relationships
         // sanitize the @has-[attribute] to valid SQL strings
         for (String s : this.attributeTypeLabels.keySet()) {
-            this.relationshipTypeLabels.add(convertTypeLabelToSqlName("@has-" + s));
+            this.relationshipTypeLabels.add("@has-" + s);
         }
+    }
 
-        this.allTypeLabels = this.getAllTypeLabels();
-
-        try {
-            clean(this.allTypeLabels);
-            dropTable("roleplayers"); // one special table for tracking role players
-        } catch (SQLException e) {
-            LOG.trace(e.getMessage(), e);
+    /**
+     * Convert raw type labels to more specific SQL names by appending _entity/_relationship/_attr
+     * This avoids clashes between SQL reserved keywords and schema labels
+     * Also converts "@" to "__"
+     */
+    private HashMap<String, String> mapLabelToSqlName(Set<String> entityLabels, Set<String> relationshipLabels, Set<String> attrLabels) {
+        HashMap<String, String> labelToSqlName = new HashMap<>();
+        for (String entityLabel : entityLabels) {
+            labelToSqlName.put(entityLabel, sanitizeString(entityLabel + "_entity"));
         }
-
-        // Register JDBC driver.
-        try {
-            Class.forName("org.apache.ignite.IgniteJdbcThinDriver");
-        } catch (ClassNotFoundException e) {
-            LOG.trace(e.getMessage(), e);
+        for (String attrLabel : attrLabels) {
+            labelToSqlName.put(attrLabel, sanitizeString(attrLabel + "_attr"));
         }
-
-        // Open JDBC connection.
-        try {
-            this.conn = DriverManager.getConnection("jdbc:ignite:thin://127.0.0.1/");
-        } catch (SQLException e) {
-            LOG.trace(e.getMessage(), e);
+        for (String relationshipLabel : relationshipLabels) {
+            labelToSqlName.put(relationshipLabel, sanitizeString(relationshipLabel + "_relationship"));
         }
-
-        // Create database tables.
-        for (String typeLabel : this.entityTypeLabels) {
-            this.createTypeIdsTable(typeLabel, relationshipTypes, attributeTypes);
-        }
-
-        for (String typeLabel : this.relationshipTypeLabels) {
-            this.createTypeIdsTable(typeLabel, relationshipTypes, attributeTypes);
-        }
-
-        for (Map.Entry<String, AttributeType.DataType<?>> entry : this.attributeTypeLabels.entrySet()) {
-            String typeLabel = entry.getKey();
-            AttributeType.DataType<?> datatype = entry.getValue();
-            String dbDatatype = DATATYPE_MAPPING.get(datatype);
-            this.createAttributeValueTable(typeLabel, dbDatatype, relationshipTypes, attributeTypes);
-        }
-
-        // re-create special table
-        // role players that have been assigned into a relationship at some point
-        createTable("roleplayers", "VARCHAR", new LinkedList<>());
+        return labelToSqlName;
     }
 
     private <T extends SchemaConcept> HashSet<String> getTypeLabels(Set<T> conceptTypes) {
@@ -139,11 +122,58 @@ public class IgniteConceptIdStore implements IdStoreInterface {
         HashMap<String, AttributeType.DataType<?>> typeLabels = new HashMap<>();
         for (AttributeType conceptType : conceptTypes) {
             String label = conceptType.label().toString();
-
             AttributeType.DataType<?> datatype = conceptType.dataType();
             typeLabels.put(label, datatype);
         }
         return typeLabels;
+    }
+
+    private void cleanTables() {
+        try {
+            clean(this.getAllTypeLabels());
+            dropTable("roleplayers"); // one special table for tracking role players
+        } catch (SQLException e) {
+            LOG.trace(e.getMessage(), e);
+        }
+    }
+
+    private void initializeSqlDriver() {
+        // Register JDBC driver.
+        try {
+            Class.forName("org.apache.ignite.IgniteJdbcThinDriver");
+        } catch (ClassNotFoundException e) {
+            LOG.trace(e.getMessage(), e);
+        }
+
+        // Open JDBC connection.
+        try {
+            this.conn = DriverManager.getConnection("jdbc:ignite:thin://127.0.0.1/");
+        } catch (SQLException e) {
+            LOG.trace(e.getMessage(), e);
+        }
+    }
+
+    private void createTables() {
+        // Create database tables.
+        for (String typeLabel : this.entityTypeLabels) {
+            this.createTypeIdsTable(typeLabel, this.relationshipTypeLabels);
+        }
+
+        for (String typeLabel : this.relationshipTypeLabels) {
+            this.createTypeIdsTable(typeLabel, this.relationshipTypeLabels);
+        }
+
+        for (Map.Entry<String, AttributeType.DataType<?>> entry : this.attributeTypeLabels.entrySet()) {
+            String typeLabel = entry.getKey();
+            AttributeType.DataType<?> datatype = entry.getValue();
+            String dbDatatype = DATATYPE_MAPPING.get(datatype);
+            this.createAttributeValueTable(typeLabel, dbDatatype, this.relationshipTypeLabels);
+        }
+
+        // re-create special table
+        // role players that have been assigned into a relationship at some point
+        createTable("roleplayers", "VARCHAR", new LinkedList<>());
+
     }
 
     private HashSet<String> getAllTypeLabels() {
@@ -158,17 +188,12 @@ public class IgniteConceptIdStore implements IdStoreInterface {
      * Create a table for storing concept IDs of the given type
      * @param typeLabel
      */
-    private void createTypeIdsTable(String typeLabel, Set<RelationshipType> relationshipTypes, Set<AttributeType> attributeTypes) {
-        String tableName = this.putTableName(typeLabel);
-        List<String> relationshipColumnNames = relationshipTypes.stream()
-                .map(relType -> convertTypeLabelToSqlName(relType.label().toString()))
+    private void createTypeIdsTable(String typeLabel, Set<String> relationshipLabels) {
+        String sqlTypeLabel = this.labelToSqlName.get(typeLabel);
+        List<String> relationshipColumnNames = relationshipLabels.stream()
+                .map(label -> this.labelToSqlName.get(label))
                 .collect(Collectors.toList());
-        List<String> hasAttributeRelationshipColumnNames = attributeTypes.stream()
-                .map(attrType -> convertTypeLabelToSqlName("@has-" + attrType.label().toString()))
-                .collect(Collectors.toList());
-
-        relationshipColumnNames.addAll(hasAttributeRelationshipColumnNames);
-        createTable(tableName, "VARCHAR", relationshipColumnNames);
+        createTable(sqlTypeLabel, "VARCHAR", relationshipColumnNames);
     }
 
     /**
@@ -177,21 +202,17 @@ public class IgniteConceptIdStore implements IdStoreInterface {
      * @param typeLabel
      * @param sqlDatatypeName
      */
-    private void createAttributeValueTable(String typeLabel, String sqlDatatypeName, Set<RelationshipType> relationshipTypes, Set<AttributeType> attributeTypes) {
+    private void createAttributeValueTable(String typeLabel,
+                                           String sqlDatatypeName,
+                                           Set<String> relationshipLabels) {
 
-        List<String> relationshipColumnNames= relationshipTypes.stream()
-                .map(relType -> convertTypeLabelToSqlName(relType.label().toString()))
+        List<String> relationshipColumnNames= relationshipLabels.stream()
+                .map(label -> this.labelToSqlName.get(label))
                 .collect(Collectors.toList());
 
-        List<String> hasAttributeRelationshipColumnNames = attributeTypes.stream()
-                .map(attrType -> convertTypeLabelToSqlName("@has-" + attrType.label().toString()))
-                .collect(Collectors.toList());
-
-        relationshipColumnNames.addAll(hasAttributeRelationshipColumnNames);
-
-        String tableName = convertTypeLabelToSqlName(typeLabel);
+        String sqlTypeLabel = this.labelToSqlName.get(typeLabel);
         try (Statement stmt = conn.createStatement()) {
-            stmt.executeUpdate("CREATE TABLE " + tableName + " (" +
+            stmt.executeUpdate("CREATE TABLE " + sqlTypeLabel + " (" +
                     " id VARCHAR PRIMARY KEY, " +
                     " value " + sqlDatatypeName + ", " +
                     joinColumnLabels(relationshipColumnNames) +
@@ -208,9 +229,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
      * @param sqlDatatypeName
      */
     private void createTable(String tableName, String sqlDatatypeName, List<String> furtherColumns) {
-
         try (Statement stmt = conn.createStatement()) {
-
             String sqlStatement = "CREATE TABLE " + tableName + " (" +
                     " id " + sqlDatatypeName + " PRIMARY KEY, " +
                     joinColumnLabels(furtherColumns) +
@@ -223,38 +242,27 @@ public class IgniteConceptIdStore implements IdStoreInterface {
         }
     }
 
+    /*
+
+    -------- helpers -------
+
+     */
+
     private String joinColumnLabels(List<String> columnLabels) {
         String joinedColumns = String.join(" VARCHAR, ", columnLabels);
         joinedColumns = joinedColumns.length() > 0 ? joinedColumns + " VARCHAR, " : joinedColumns;
         return joinedColumns;
     }
 
-    private String convertTypeLabelToSqlName(String typeLabel) {
-        return typeLabel.replace('-', '_').replace("@", "__");
-    }
-
-    private String putTableName(String typeLabel) {
-        String tableName = this.convertTypeLabelToSqlName(typeLabel);
-        this.typeLabelsTotableNames.put(typeLabel, tableName);
-        return tableName;
-    }
-
-    private String getTableName(String typeLabel) {
-
-        String tableName = this.typeLabelsTotableNames.get(typeLabel);
-        if (tableName != null) {
-            return tableName;
-        } else {
-            // TODO Don't need this else clause if I can figure out how to drop all tables in clean()
-            return convertTypeLabelToSqlName(typeLabel);
-        }
+    private String sanitizeString(String string) {
+        return string.replace('-', '_').replace("@", "__");
     }
 
     @Override
     public void addConcept(Concept concept) {
 
         Label conceptTypeLabel = concept.asThing().type().label();
-        String tableName = this.getTableName(conceptTypeLabel.toString());
+        String tableName = this.labelToSqlName.get(conceptTypeLabel.toString());
         String conceptId = concept.asThing().id().toString(); // TODO use the value instead for attributes
 
         if (concept.isAttribute()) {
@@ -358,9 +366,9 @@ public class IgniteConceptIdStore implements IdStoreInterface {
 
     private void addRolePlayerForConcept(String conceptId, String type, String relationshipType, String role) {
         // add the role to this concept ID's row/column for this relationship
-        String sqlTypeTable = convertTypeLabelToSqlName(type);
-        String sqlRelationship = convertTypeLabelToSqlName(relationshipType);
-        String sqlRole = convertTypeLabelToSqlName(role);
+        String sqlTypeTable = this.labelToSqlName.get(type);
+        String sqlRelationship = this.labelToSqlName.get(relationshipType);
+        String sqlRole = sanitizeString(role);
 
         try (Statement stmt = conn.createStatement()) {
             // do a select to retrieve currently filled roles by this conceptID in this relationship
@@ -391,9 +399,9 @@ public class IgniteConceptIdStore implements IdStoreInterface {
      * String hacks to stuff all the roles played by a concept of a given type in a specific relationship into one string
      */
     public List<String> getIdsNotPlayingRole(String typeLabel, String relationshipType, String role) {
-        String tableName = convertTypeLabelToSqlName(typeLabel);
-        String columnName = convertTypeLabelToSqlName(relationshipType);
-        String roleName = convertTypeLabelToSqlName(role);
+        String tableName = this.labelToSqlName.get(typeLabel);
+        String columnName = this.labelToSqlName.get(relationshipType);
+        String roleName = sanitizeString(role);
 
         String sql = "SELECT ID, " + columnName + " FROM " + tableName +
                 " WHERE (" + columnName + " IS NULL OR " + columnName + "  NOT LIKE '%" + roleName + "%')";
@@ -415,9 +423,9 @@ public class IgniteConceptIdStore implements IdStoreInterface {
     }
 
     public Integer numIdsNotPlayingRole(String typeLabel, String relationshipType, String role) {
-        String tableName = convertTypeLabelToSqlName(typeLabel);
-        String columnName = convertTypeLabelToSqlName(relationshipType);
-        String roleName = convertTypeLabelToSqlName(role);
+        String tableName = this.labelToSqlName.get(typeLabel);
+        String columnName = this.labelToSqlName.get(relationshipType);
+        String roleName = sanitizeString(role);
 
         String sql = "SELECT COUNT(ID) FROM " + tableName +
                 " WHERE (" + columnName + " IS NULL OR " + columnName + "  NOT LIKE '%" + roleName + "%')";
@@ -442,14 +450,14 @@ public class IgniteConceptIdStore implements IdStoreInterface {
      */
 
     private String sqlGetId(String typeLabel, int offset) {
-        String sql = "SELECT id FROM " + getTableName(typeLabel) +
+        String sql = "SELECT id FROM " + labelToSqlName.get(typeLabel) +
                 " OFFSET " + offset +
                 " FETCH FIRST ROW ONLY";
         return sql;
     }
 
     private String sqlGetAttrValue(String typeLabel, int offset) {
-        String sql = "SELECT value FROM " + getTableName(typeLabel) +
+        String sql = "SELECT value FROM " + labelToSqlName.get(typeLabel) +
                 " OFFSET " + offset +
                 " FETCH FIRST ROW ONLY";
         return sql;
@@ -547,7 +555,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
     }
 
     public int getConceptCount(String typeLabel) {
-        String tableName = getTableName(typeLabel);
+        String tableName = labelToSqlName.get(typeLabel);
         return getCountInTable(tableName);
     }
 
@@ -596,7 +604,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
         Set<String> rolePlayerIds = getIds("roleplayers");
         Set<String> entityIds = new HashSet<>();
         for (String typeLabel: this.entityTypeLabels) {
-            Set<String> ids = getIds(getTableName(typeLabel));
+            Set<String> ids = getIds(this.labelToSqlName.get(typeLabel));
             entityIds.addAll(ids);
         }
         entityIds.removeAll(rolePlayerIds);
@@ -612,7 +620,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
         Set<String> rolePlayerIds = getIds("roleplayers");
         Set<String> attributeIds = new HashSet<>();
         for (String typeLabel: this.attributeTypeLabels.keySet()) {
-            Set<String> ids = getIds(getTableName(typeLabel));
+            Set<String> ids = getIds(this.labelToSqlName.get(typeLabel));
             attributeIds.addAll(ids);
         }
         attributeIds.removeAll(rolePlayerIds);
@@ -629,7 +637,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
         Set<String> rolePlayerIds = getIds("roleplayers");
         Set<String> relationshipIds = new HashSet<>();
         for (String typeLabel: this.relationshipTypeLabels) {
-            Set<String> ids = getIds(getTableName(typeLabel));
+            Set<String> ids = getIds(this.labelToSqlName.get(typeLabel));
             relationshipIds.addAll(ids);
         }
         relationshipIds.retainAll(rolePlayerIds);
@@ -659,13 +667,13 @@ public class IgniteConceptIdStore implements IdStoreInterface {
      */
     public void clean(Set<String> typeLabels) throws SQLException {
         for (String typeLabel : typeLabels) {
-            dropTable(getTableName(typeLabel));
+            dropTable(this.labelToSqlName.get(typeLabel));
         }
     }
 
     private void dropTable(String tableName) throws SQLException {
         Connection conn = DriverManager.getConnection("jdbc:ignite:thin://127.0.0.1/");
-        try (PreparedStatement stmt = conn.prepareStatement("DROP TABLE IF EXISTS " + this.getTableName(tableName))) {
+        try (PreparedStatement stmt = conn.prepareStatement("DROP TABLE IF EXISTS " + tableName)) {
             stmt.executeUpdate();
         } catch (SQLException e) {
             LOG.trace(e.getMessage(), e);

--- a/runner/src/storage/SchemaManager.java
+++ b/runner/src/storage/SchemaManager.java
@@ -54,39 +54,8 @@ public class SchemaManager {
     }
 
     public static void initialiseKeyspace(Grakn.Session session, List<String> graqlSchemaQueries) {
-        clearKeyspace(session);
         try (Grakn.Transaction tx = session.transaction(GraknTxType.WRITE)) {
             tx.graql().parser().parseList(graqlSchemaQueries.stream().collect(Collectors.joining("\n"))).forEach(Query::execute);
-            tx.commit();
-        }
-    }
-
-    private static void clearKeyspace(Grakn.Session session) {
-        try (Grakn.Transaction tx = session.transaction(GraknTxType.WRITE)) {
-            // delete all attributes, relationships, entities from keyspace
-
-            QueryBuilder qb = tx.graql();
-            Var x = Graql.var().asUserDefined();  //TODO This needed to be asUserDefined or else getting error: ai.grakn.exception.GraqlQueryException: the variable $1528883020589004 is not in the query
-            Var y = Graql.var().asUserDefined();
-
-            // TODO Sporadically has errors, logged in bug #20200
-
-            // cannot use delete "thing", complains
-            qb.match(x.isa("attribute")).delete(x).execute();
-            qb.match(x.isa("relationship")).delete(x).execute();
-            qb.match(x.isa("entity")).delete(x).execute();
-
-            //
-//            qb.undefine(y.sub("thing")).execute(); // TODO undefine $y sub thing; doesn't work/isn't supported
-            // TODO undefine $y sub entity; also doesn't work, you need to be specific with undefine
-
-            List<ConceptMap> schema = qb.match(y.sub("thing")).get().execute();
-
-            for (ConceptMap element : schema) {
-                Var z = Graql.var().asUserDefined();
-                qb.undefine(z.id(element.get(y).id())).execute();
-            }
-
             tx.commit();
         }
     }

--- a/runner/test/pick/BUILD
+++ b/runner/test/pick/BUILD
@@ -1,0 +1,11 @@
+
+java_test(
+    name = "central-stream-provider-test",
+    test_class = "grakn.benchmark.runner.pick.CentralStreamProviderTest",
+    srcs = ["CentralStreamProviderTest.java"],
+    deps = [
+        "//runner:benchmark-runner",
+        "//dependencies/maven/artifacts/org/mockito:mockito-core",
+        "//dependencies/maven/artifacts/org/hamcrest:hamcrest-all"
+    ]
+)

--- a/runner/test/pick/CentralStreamProviderTest.java
+++ b/runner/test/pick/CentralStreamProviderTest.java
@@ -1,0 +1,112 @@
+package grakn.benchmark.runner.pick;
+
+import grakn.benchmark.runner.probdensity.FixedConstant;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CentralStreamProviderTest {
+
+    @Test
+    public void whenSingleCentralObject_objectIsRepeated() {
+
+        FixedConstant one = new FixedConstant(1);
+
+        StreamInterface<Integer> streamer = mock(StreamInterface.class);
+        List<Integer> ints = IntStream.range(0, 10).boxed().collect(Collectors.toList());
+        when(streamer.getStream(any())).thenReturn(ints.stream());
+
+        FixedConstant five = new FixedConstant(5);
+
+        CentralStreamProvider<Integer> centralStreamProvider = new CentralStreamProvider<>(one, streamer);
+        Stream<Integer> centralStream = centralStreamProvider.getStream(five, null);
+
+        List<Integer> centralIntegers = centralStream.collect(Collectors.toList());
+
+        List<Integer> expectedIntegers = Arrays.asList(0, 0, 0, 0, 0);
+
+        Assert.assertThat(centralIntegers, is(expectedIntegers));
+    }
+
+    @Test
+    public void whenMultipleCentralObject_objectsCyclicallyRepeated() {
+
+        FixedConstant three = new FixedConstant(3);
+
+        StreamInterface<Integer> streamer = mock(StreamInterface.class);
+        List<Integer> ints = IntStream.range(0, 10).boxed().collect(Collectors.toList());
+        when(streamer.getStream(any())).thenReturn(ints.stream());
+
+        FixedConstant five = new FixedConstant(5);
+
+        CentralStreamProvider<Integer> centralStreamProvider = new CentralStreamProvider<>(three, streamer);
+        Stream<Integer> centralStream = centralStreamProvider.getStream(five, null);
+
+        List<Integer> centralIntegers = centralStream.collect(Collectors.toList());
+
+        List<Integer> expectedIntegers = Arrays.asList(0, 1, 2, 0, 1);
+
+        Assert.assertThat(centralIntegers, is(expectedIntegers));
+    }
+
+    @Test
+    public void whenMultipleCentralObjectCalledTwice_objectsCycleContinued() {
+
+        FixedConstant three = new FixedConstant(3);
+
+        StreamInterface<Integer> streamer = mock(StreamInterface.class);
+        List<Integer> ints = IntStream.range(0, 10).boxed().collect(Collectors.toList());
+        when(streamer.getStream(any())).thenReturn(ints.stream());
+
+        FixedConstant five = new FixedConstant(5);
+
+        CentralStreamProvider<Integer> centralStreamProvider = new CentralStreamProvider<>(three, streamer);
+        Stream<Integer> centralStream = centralStreamProvider.getStream(five, null);
+
+        List<Integer> centralIntegers = centralStream.collect(Collectors.toList());
+        List<Integer> expectedIntegers = Arrays.asList(0, 1, 2, 0, 1);
+        Assert.assertThat(centralIntegers, is(expectedIntegers));
+
+        Stream<Integer> centralStreamTwo = centralStreamProvider.getStream(five, null);
+        List<Integer> centralIntegersTwo = centralStreamTwo.collect(Collectors.toList());
+        List<Integer> expectedIntegersTwo = Arrays.asList(2, 0, 1, 2, 0);
+        Assert.assertThat(centralIntegersTwo, is(expectedIntegersTwo));
+    }
+
+
+    @Test
+    public void whenMultipleCentralObjectCalledTwiceWithReset_cycleIsReset() {
+
+        FixedConstant three = new FixedConstant(3);
+
+        StreamInterface<Integer> streamer = mock(StreamInterface.class);
+        List<Integer> ints = IntStream.range(0, 10).boxed().collect(Collectors.toList());
+        when(streamer.getStream(any())).thenReturn(ints.stream()).thenReturn(ints.stream());
+
+        FixedConstant five = new FixedConstant(5);
+
+        CentralStreamProvider<Integer> centralStreamProvider = new CentralStreamProvider<>(three, streamer);
+        Stream<Integer> centralStream = centralStreamProvider.getStream(five, null);
+
+        List<Integer> centralIntegers = centralStream.collect(Collectors.toList());
+        List<Integer> expectedIntegers = Arrays.asList(0, 1, 2, 0, 1);
+        Assert.assertThat(centralIntegers, is(expectedIntegers));
+
+        centralStreamProvider.reset();
+
+        Stream<Integer> centralStreamTwo = centralStreamProvider.getStream(five, null);
+        List<Integer> centralIntegersTwo = centralStreamTwo.collect(Collectors.toList());
+        List<Integer> expectedIntegersTwo = Arrays.asList(0, 1, 2, 0, 1);
+        Assert.assertThat(centralIntegersTwo, is(expectedIntegersTwo));
+    }
+}

--- a/runner/test/storage/IgniteConceptIdStoreTest.java
+++ b/runner/test/storage/IgniteConceptIdStoreTest.java
@@ -178,7 +178,7 @@ public class IgniteConceptIdStoreTest {
         // Check objects were added to the db
         Connection conn = DriverManager.getConnection("jdbc:ignite:thin://127.0.0.1/");
         try (Statement stmt = conn.createStatement()) {
-            try (ResultSet rs = stmt.executeQuery("SELECT * FROM " + this.entityTypeLabel)) {
+            try (ResultSet rs = stmt.executeQuery("SELECT * FROM " + this.entityTypeLabel + "_entity")) {
                 while (rs.next()) {
                     counter++;
                 }


### PR DESCRIPTION
Implements new schemas for all four new benchmarking graphs, plus end to end completed implementations for Social Network and Road network graphs.

Also refactored CentralStreamProvider to repeat a set of central objects until reset, operating on a list of objects in a circular-buffer style. With these changes added tests for CentralStreamProvider that defines the new functionality.