### PR TITLE
Refactor metrics and scale accounting in Data Generator

### DIFF
--- a/runner/conf/road_network/road_config.yml
+++ b/runner/conf/road_network/road_config.yml
@@ -2,7 +2,12 @@ graphName: "road_network"
 schema: "road_network.gql"
 queries: "queries.yml"
 scales:
-- 500
+ - 2000
+ - 4000
+ - 6000
+ - 8000
+ - 10000
+
 repeatsPerQuery: 1
   # TODO
   # concurrency:

--- a/runner/conf/social_network/social_network_config.yml
+++ b/runner/conf/social_network/social_network_config.yml
@@ -2,7 +2,11 @@ graphName: "social_network"
 schema: "social_network.gql"
 queries: "queries.yml"
 scales:
-- 500
+ - 2000
+ - 4000
+ - 6000
+ - 8000
+ - 10000
 repeatsPerQuery: 1
   # TODO
   # concurrency:

--- a/runner/src/GraknBenchmark.java
+++ b/runner/src/GraknBenchmark.java
@@ -98,7 +98,7 @@ public class GraknBenchmark {
 
             List<Integer> numConceptsInRun = config.scalesToProfile();
             for (int numConcepts : numConceptsInRun) {
-                LOG.info("Running queries with " + numConcepts + " concepts");
+                LOG.info("Generating graph to scale... " + numConcepts);
                 dataGenerator.generate(numConcepts);
                 queryProfiler.processStaticQueries(repetitionsPerQuery, numConcepts);
             }

--- a/runner/src/executor/QueryProfiler.java
+++ b/runner/src/executor/QueryProfiler.java
@@ -77,7 +77,6 @@ public class QueryProfiler {
     }
 
     void processQueries(Stream<Query> queryStream, int repetitions, int numConcepts) throws Exception {
-
         try (Grakn.Transaction tx = session.transaction(GraknTxType.WRITE)) {
             Tracer tracer = Tracing.currentTracer();
 
@@ -88,7 +87,8 @@ public class QueryProfiler {
                 for (Query rawQuery : queries) {
                     Query query = rawQuery.withTx(tx);
 
-                    LOG.info("Running query iteration " + rep + ": " + query.toString());
+                    this.eraselinePrint(String.format("Profiling... (repetition %d/%d):\t%s", rep+1, repetitions, query.toString()));
+                    LOG.info("Profiling... repetition " + rep + ": " + query.toString());
                     Span querySpan = tracer.newTrace().name("query");
                     querySpan.tag("scale", Integer.toString(numConcepts));
                     querySpan.tag("query", query.toString());
@@ -114,5 +114,11 @@ public class QueryProfiler {
             // wait for out-of-band reporting to complete
             Thread.sleep(1500);
         }
+        System.out.print("\n\n");
+    }
+
+    private void eraselinePrint(String msg) {
+        System.out.print("\r");
+        System.out.print(msg);
     }
 }

--- a/runner/src/generator/DataGenerator.java
+++ b/runner/src/generator/DataGenerator.java
@@ -173,13 +173,13 @@ public class DataGenerator {
 
         // print info to console on one self-erasing line
         System.out.print("\r");
-        System.out.print(String.format("[%d]  Scale: %d\t(%f Deg_Cin, %f Deg_Rout, %f Deg_Aout)\t(%d, %d, %d) Entity/Rel/Attr \t (%d EO, %d AO) \t %f density",
-                this.iteration, graphScale, meanInDegree, meanRolePlayersPerRelationship, meanAttributeOwners,
+        System.out.print(String.format("[%d] %s Scale: %d\t(%f Deg_Cin, %f Deg_Rout, %f Deg_Aout)\t(%d, %d, %d) Entity/Rel/Attr \t (%d EO, %d AO) \t %f density",
+                this.iteration, this.graphName, graphScale, meanInDegree, meanRolePlayersPerRelationship, meanAttributeOwners,
                 entities, explicitRelationships, attributes,
                 orphanEntities, orphanAttrs, density));
 
         // write to log verbosely in DEBUG that it doesn't overwrite
-        LOG.debug(String.format("----- Iteration %d ----- ", this.iteration));
+        LOG.debug(String.format("----- Iteration %d [%s] ----- ", this.iteration, this.graphName));
         LOG.debug(String.format(">> Generating instances of concept type \"%s\"", generatedTypeLabel));
         LOG.debug(String.format(">> %d - Scale", graphScale));
         LOG.debug(String.format(">> %d, %d, %d - entity, explicit relationships, attributes", entities, explicitRelationships, attributes));

--- a/runner/src/generator/DataGenerator.java
+++ b/runner/src/generator/DataGenerator.java
@@ -147,13 +147,13 @@ public class DataGenerator {
         int orphanEntities = this.storage.totalOrphanEntities();
         int orphanAttrs = this.storage.totalOrphanAttributes();
         int relDoubleCounts = this.storage.totalRelationshipsRolePlayersOverlap();
-        int relationships = this.storage.totalRelationships();
+//        int relationships = this.storage.totalRelationships();
 
-        double density = relationships/((double)graphScale * graphScale);
+//        double density = relationships/((double)graphScale * graphScale);
 
         // print info to console on one self-erasing line
         System.out.print("\r");
-        System.out.print(String.format("[%d]  Scale: %d\t(%d RP, %d EO, %d AO, %d DC)\t\tRelationships: %d\t\t Density: %f", this.iteration, graphScale, rolePlayers, orphanEntities, orphanAttrs, relDoubleCounts, relationships, density));
+//        System.out.print(String.format("[%d]  Scale: %d\t(%d RP, %d EO, %d AO, %d DC)\t\tRelationships: %d\t\t Density: %f", this.iteration, graphScale, rolePlayers, orphanEntities, orphanAttrs, relDoubleCounts, relationships, density));
         System.out.flush();
 
         // write to log verbosely in DEBUG that it doesn't overwrite
@@ -164,8 +164,8 @@ public class DataGenerator {
         LOG.debug(String.format("## %d entity orphans", orphanEntities));
         LOG.debug(String.format("## %d attribute orphans", orphanAttrs));
         LOG.debug(String.format("## %d Rel double counts", relDoubleCounts));
-        LOG.debug(String.format("## %d Relationships", relationships));
-        LOG.debug(String.format("## %f Density", density));
+//        LOG.debug(String.format("## %d Relationships", relationships));
+//        LOG.debug(String.format("## %f Density", density));
     }
 
 }

--- a/runner/src/generator/DataGenerator.java
+++ b/runner/src/generator/DataGenerator.java
@@ -87,7 +87,6 @@ public class DataGenerator {
         effectively paused while benchmarking takes place
         */
 
-        System.out.println("\n");
         GeneratorFactory gf = new GeneratorFactory();
         int graphScale = dataStrategies.getGraphScale();
 
@@ -103,12 +102,12 @@ public class DataGenerator {
                 this.processQueryStream(queryStream);
                 iteration++;
 
-                printProgress(graphScale, typeStrategy.getTypeLabel());
                 graphScale = dataStrategies.getGraphScale();
+                printProgress(graphScale, typeStrategy.getTypeLabel());
                 tx.commit();
             }
         }
-        System.out.println("\n");
+        System.out.print("\n");
     }
 
     private void processQueryStream(Stream<Query> queryStream) {
@@ -143,29 +142,54 @@ public class DataGenerator {
 
 
     private void printProgress(int graphScale, String generatedTypeLabel) {
-        int rolePlayers = this.storage.totalRolePlayers();
+        int totalRolePlayers = this.storage.totalRolePlayers();
+        int explicitRolePlayers = this.storage.totalExplicitRolePlayers();
+        // this should actually == number of implicit relationships!
+        int attributeOwners = (totalRolePlayers - explicitRolePlayers)/2;
+
+        int entities = this.storage.totalEntities();
+        int explicitRelationships = this.storage.totalExplicitRelationships();
+        int attributes = this.storage.totalAttributes();
+
+
         int orphanEntities = this.storage.totalOrphanEntities();
         int orphanAttrs = this.storage.totalOrphanAttributes();
         int relDoubleCounts = this.storage.totalRelationshipsRolePlayersOverlap();
-//        int relationships = this.storage.totalRelationships();
 
-//        double density = relationships/((double)graphScale * graphScale);
+
+        // first order statistics
+        double meanInDegree = ((float) explicitRolePlayers)/graphScale;
+        double meanRolePlayersPerRelationship = ((float) explicitRolePlayers) / explicitRelationships;
+        double meanAttributeOwners = ((float) attributeOwners) / attributes;
+        double proportionEntities = ((float) entities) / graphScale;
+        double proportionRelationships = ((float) explicitRelationships) / graphScale;
+        double proportionAttributes = ((float) attributes) / graphScale;
+
+        // our own density measure
+        // compute how many connections (ie role players) there would be if everyone were fully connected to everything
+        double maxPossibleConnections = attributes * graphScale + explicitRelationships * graphScale;
+        double density = ((float) totalRolePlayers) / maxPossibleConnections;
+
 
         // print info to console on one self-erasing line
         System.out.print("\r");
-//        System.out.print(String.format("[%d]  Scale: %d\t(%d RP, %d EO, %d AO, %d DC)\t\tRelationships: %d\t\t Density: %f", this.iteration, graphScale, rolePlayers, orphanEntities, orphanAttrs, relDoubleCounts, relationships, density));
-        System.out.flush();
+        System.out.print(String.format("[%d]  Scale: %d\t(%f Deg_Cin, %f Deg_Rout, %f Deg_Aout)\t(%d, %d, %d) Entity/Rel/Attr \t (%d EO, %d AO) \t %f density",
+                this.iteration, graphScale, meanInDegree, meanRolePlayersPerRelationship, meanAttributeOwners,
+                entities, explicitRelationships, attributes,
+                orphanEntities, orphanAttrs, density));
 
         // write to log verbosely in DEBUG that it doesn't overwrite
-        LOG.debug(String.format("--- Iteration %d --- ", this.iteration));
-        LOG.debug(String.format("## Generating instances of concept type \"%s\"", generatedTypeLabel));
-        LOG.debug(String.format("## Scale: %d", graphScale));
-        LOG.debug(String.format("## %d role players", rolePlayers));
-        LOG.debug(String.format("## %d entity orphans", orphanEntities));
-        LOG.debug(String.format("## %d attribute orphans", orphanAttrs));
-        LOG.debug(String.format("## %d Rel double counts", relDoubleCounts));
-//        LOG.debug(String.format("## %d Relationships", relationships));
-//        LOG.debug(String.format("## %f Density", density));
+        LOG.debug(String.format("----- Iteration %d ----- ", this.iteration));
+        LOG.debug(String.format(">> Generating instances of concept type \"%s\"", generatedTypeLabel));
+        LOG.debug(String.format(">> %d - Scale", graphScale));
+        LOG.debug(String.format(">> %d, %d, %d - entity, explicit relationships, attributes", entities, explicitRelationships, attributes));
+        LOG.debug(String.format(">> %d, %d - entity orphans, attribute orphans ", orphanEntities, orphanAttrs));
+        LOG.debug(String.format(">> %d - Total relationship double counts", relDoubleCounts));
+        LOG.debug(String.format(">> %f, %f, %f - mean Deg_Cin, mean Deg_Rout, mean Deg_Aout",
+                meanInDegree, meanRolePlayersPerRelationship, meanAttributeOwners));
+        LOG.debug(String.format(">> %f, %f %f - proportion entities, relationships, attributes",
+                proportionEntities, proportionRelationships, proportionAttributes));
+        LOG.debug(String.format(">> %f - custom density", density));
     }
 
 }

--- a/runner/src/schemaspecific/SchemaSpecificDataGenerator.java
+++ b/runner/src/schemaspecific/SchemaSpecificDataGenerator.java
@@ -11,9 +11,9 @@ public interface SchemaSpecificDataGenerator {
     ConceptStore getConceptStore();
     default int getGraphScale() {
         ConceptStore storage = getConceptStore();
-        int rolePlayers = storage.totalRolePlayers();
-        int orphanEntities = storage.totalOrphanEntities();
-        int orphanAttributes = storage.totalOrphanAttributes();
-        return rolePlayers + orphanAttributes + orphanEntities;
+        int entities = storage.totalEntities();
+        int attributes = storage.totalAttributes();
+        int relationships = storage.totalExplicitRelationships();
+        return entities + attributes + relationships;
     }
 }

--- a/runner/src/storage/ConceptStore.java
+++ b/runner/src/storage/ConceptStore.java
@@ -26,11 +26,15 @@ import grakn.core.concept.Concept;
 public interface ConceptStore {
 
     void addConcept(Concept concept);
-    void addRolePlayer(String conceptId);
     void addRolePlayer(String conceptId, String conceptType, String relationshipType, String role);
 
-    int totalRelationships();
+    int totalExplicitRelationships();
+    int totalEntities();
+    int totalAttributes();
+
     int totalRolePlayers();
+    int totalExplicitRolePlayers();
+
     int totalOrphanEntities();
     int totalOrphanAttributes();
     int totalRelationshipsRolePlayersOverlap();

--- a/runner/src/storage/IgniteConceptIdStore.java
+++ b/runner/src/storage/IgniteConceptIdStore.java
@@ -668,7 +668,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
     }
 
     /**
-     * Double counting between relationships and relationships also playing roles
+     * Double counting between relationships and relationships also playing roles (including implicit and explicit rels)
      * = Set(All relationship ids) intersect Set(role players)
      * @return
      */

--- a/runner/src/storage/IgniteConceptIdStore.java
+++ b/runner/src/storage/IgniteConceptIdStore.java
@@ -387,15 +387,13 @@ public class IgniteConceptIdStore implements IdStoreInterface {
         try (Statement stmt = conn.createStatement()) {
             String checkExists = "SELECT id FROM roleplayers WHERE id = '" + conceptId + "'";
             try (ResultSet rs = stmt.executeQuery(checkExists)) {
-                if (rs.next()) {
-                    // if we have any rows matching this ID, skip
-                    return;
+                if (!rs.next()) {
+                    String addRolePlayer = "INSERT INTO roleplayers (id, ) VALUES ('"+conceptId+"')";
+                    stmt.executeUpdate(addRolePlayer);
                 }
             } catch (SQLException e) {
                 LOG.trace(e.getMessage(), e);
             }
-            String addRolePlayer = "INSERT INTO roleplayers (id, ) VALUES ('"+conceptId+"')";
-            stmt.executeUpdate(addRolePlayer);
         } catch (SQLException e) {
             LOG.trace(e.getMessage(), e);
         }

--- a/runner/src/storage/IgniteConceptIdStore.java
+++ b/runner/src/storage/IgniteConceptIdStore.java
@@ -47,6 +47,7 @@ public class IgniteConceptIdStore implements IdStoreInterface {
 
     private HashSet<String> entityTypeLabels;
     private HashSet<String> relationshipTypeLabels;
+    private HashSet<String> explicitRelationshipTypeLabels;
     private HashMap<java.lang.String, AttributeType.DataType<?>> attributeTypeLabels; // typeLabel, datatype
     private HashMap<String, String> labelToSqlName;
 
@@ -54,6 +55,12 @@ public class IgniteConceptIdStore implements IdStoreInterface {
     private final String cachingMethod = "REPLICATED";
     private final int ID_INDEX = 1;
     private final int VALUE_INDEX = 2;
+
+    // store a counter for number of role players because the ignite tables de-duplicate IDs that play multiple roles
+    // total is implicit + explicit role players
+    private int totalRolePlayers = 0;
+    // separately count only roles that are in explicit relationships
+    private int totalExplicitRolePlayers = 0;
 
     public static final Map<AttributeType.DataType<?>, String> DATATYPE_MAPPING;
     static {
@@ -82,13 +89,16 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                                    Set<RelationshipType> relationshipTypes,
                                    Set<AttributeType> attributeTypes) {
         this.entityTypeLabels = this.getTypeLabels(entityTypes);
-        this.relationshipTypeLabels = this.getTypeLabels(relationshipTypes);
+        this.explicitRelationshipTypeLabels = this.getTypeLabels(relationshipTypes);
         this.attributeTypeLabels = this.getAttributeTypeLabels(attributeTypes);
+
+        this.relationshipTypeLabels = this.getTypeLabels(relationshipTypes);
         // add @has-[attribute] relationships as possible relationships
         // sanitize the @has-[attribute] to valid SQL strings
         for (String s : this.attributeTypeLabels.keySet()) {
             this.relationshipTypeLabels.add("@has-" + s);
         }
+
     }
 
     /**
@@ -329,29 +339,6 @@ public class IgniteConceptIdStore implements IdStoreInterface {
     }
 
     /**
-     * Add a role player without specifying the specific relationship & role it fills
-     * @param conceptId
-     */
-    public void addRolePlayer(String conceptId) {
-        // add the conceptID to the overall role players table
-        try (Statement stmt = conn.createStatement()) {
-            String checkExists = "SELECT id FROM roleplayers WHERE id = '" + conceptId + "'";
-            try (ResultSet rs = stmt.executeQuery(checkExists)) {
-                if (rs.next()) {
-                    // if we have any rows matching this ID, skip
-                    return;
-                }
-            } catch (SQLException e) {
-                LOG.trace(e.getMessage(), e);
-            }
-            String addRolePlayer = "INSERT INTO roleplayers (id, ) VALUES ('"+conceptId+"')";
-            stmt.executeUpdate(addRolePlayer);
-        } catch (SQLException e) {
-            LOG.trace(e.getMessage(), e);
-        }
-    }
-
-    /**
      * Add a role player, and specify its type, the relationship, and role it fills
      * This will track
      * @param conceptId
@@ -360,13 +347,15 @@ public class IgniteConceptIdStore implements IdStoreInterface {
      * @param role
      */
     public void addRolePlayer(String conceptId, String conceptType, String relationshipType, String role) {
-        addRolePlayer(conceptId);
-        addRolePlayerForConcept(conceptId, conceptType, relationshipType, role);
-    }
 
-    private void addRolePlayerForConcept(String conceptId, String type, String relationshipType, String role) {
+        // update in-memory accounting
+        totalRolePlayers += 1;
+        if (!relationshipType.startsWith("@")) {
+            totalExplicitRolePlayers += 1;
+        }
+
         // add the role to this concept ID's row/column for this relationship
-        String sqlTypeTable = this.labelToSqlName.get(type);
+        String sqlTypeTable = this.labelToSqlName.get(conceptType);
         String sqlRelationship = this.labelToSqlName.get(relationshipType);
         String sqlRole = sanitizeString(role);
 
@@ -390,6 +379,23 @@ public class IgniteConceptIdStore implements IdStoreInterface {
                         " WHERE id = '" + conceptId + "'";
                 stmt.executeUpdate(setCurrentRolesSql);
             }
+        } catch (SQLException e) {
+            LOG.trace(e.getMessage(), e);
+        }
+
+        // add the conceptID to the overall role players table
+        try (Statement stmt = conn.createStatement()) {
+            String checkExists = "SELECT id FROM roleplayers WHERE id = '" + conceptId + "'";
+            try (ResultSet rs = stmt.executeQuery(checkExists)) {
+                if (rs.next()) {
+                    // if we have any rows matching this ID, skip
+                    return;
+                }
+            } catch (SQLException e) {
+                LOG.trace(e.getMessage(), e);
+            }
+            String addRolePlayer = "INSERT INTO roleplayers (id, ) VALUES ('"+conceptId+"')";
+            stmt.executeUpdate(addRolePlayer);
         } catch (SQLException e) {
             LOG.trace(e.getMessage(), e);
         }
@@ -582,17 +588,51 @@ public class IgniteConceptIdStore implements IdStoreInterface {
     }
 
     @Override
-    public int totalRelationships() {
+    public int totalExplicitRelationships() {
         int total = 0;
-        for (String relationshipType : this.relationshipTypeLabels) {
+        for (String relationshipType : this.explicitRelationshipTypeLabels) {
             total += getConceptCount(relationshipType);
         }
         return total;
     }
 
     @Override
+    public int totalEntities() {
+        int total = 0;
+        for (String entityType : this.entityTypeLabels) {
+            total += getConceptCount(entityType);
+        }
+        return total;
+    }
+
+    @Override
+    public int totalAttributes() {
+        int total = 0;
+        for (String attributeType : this.attributeTypeLabels.keySet()) {
+            total += getConceptCount(attributeType);
+        }
+        return total;
+    }
+
+
+    /**
+     * Return total count of number of role players (repeat counts of the same concept playing multiples roles is
+     * counted repeatedly, not once)
+     * @return
+     */
+    @Override
     public int totalRolePlayers() {
-        return getCountInTable("roleplayers");
+        return totalRolePlayers;
+    }
+
+    /**
+     * Return total count of number of role players (repeat counts of the same concept playing multiples roles is
+     * counted repeatedly, not once)
+     * @return
+     */
+    @Override
+    public int totalExplicitRolePlayers() {
+        return totalExplicitRolePlayers;
     }
 
     /**

--- a/runner/test/storage/IgniteConceptIdStoreTest.java
+++ b/runner/test/storage/IgniteConceptIdStoreTest.java
@@ -48,7 +48,6 @@ public class IgniteConceptIdStoreTest {
 
     private IgniteConceptIdStore store;
     private HashSet<String> typeLabelsSet;
-    private ArrayList<String> typeLabels;
     private ArrayList<ConceptId> conceptIds;
     private ArrayList<Concept> conceptMocks;
     private String entityTypeLabel;
@@ -223,16 +222,6 @@ public class IgniteConceptIdStoreTest {
     }
 
     @Test
-    public void whenRolePlayerIsAdded_countIsCorrect() {
-        for (Concept conceptMock : this.conceptMocks) {
-            this.store.addRolePlayer(conceptMock.asThing().id().toString());
-        }
-
-        int roleplayerCount = this.store.totalRolePlayers();
-        assertEquals(9, roleplayerCount);
-    }
-
-    @Test
     public void whenAllButOnePlayingRole_orphanEntitiesCorrect() {
         // add all concepts to store
         for (Concept conceptMock : this.conceptMocks) {
@@ -242,7 +231,8 @@ public class IgniteConceptIdStoreTest {
         // add 6 of 7 entities as role players too
         for (int i = 0 ; i < 6; i++) {
             Concept conceptMock = this.conceptMocks.get(i);
-            this.store.addRolePlayer(conceptMock.asThing().id().toString());
+            Thing thing = conceptMock.asThing();
+            this.store.addRolePlayer(thing.id().toString(), thing.type().label().toString(), relTypeLabel, "somerole");
         }
 
         int orphanEntities = this.store.totalOrphanEntities();
@@ -259,7 +249,8 @@ public class IgniteConceptIdStoreTest {
         // ad all but the attribute and relationship
         for (int i = 0 ; i < conceptMocks.size()-2; i++) {
             Concept conceptMock = this.conceptMocks.get(i);
-            this.store.addRolePlayer(conceptMock.asThing().id().toString());
+            Thing thing = conceptMock.asThing();
+            this.store.addRolePlayer(thing.id().toString(), thing.type().label().toString(), relTypeLabel,"somerole");
         }
 
         int orphanAttributes = this.store.totalOrphanAttributes();
@@ -276,7 +267,8 @@ public class IgniteConceptIdStoreTest {
         // add all but the relationship (last element)
         for (int i = 0 ; i < conceptMocks.size()-1; i++) {
             Concept conceptMock = this.conceptMocks.get(i);
-            this.store.addRolePlayer(conceptMock.asThing().id().toString());
+            Thing thing = conceptMock.asThing();
+            this.store.addRolePlayer(thing.id().toString(), thing.type().label().toString(), relTypeLabel, "somerole");
         }
 
         int relationshipDoubleCounts = this.store.totalRelationshipsRolePlayersOverlap();
@@ -293,7 +285,8 @@ public class IgniteConceptIdStoreTest {
         // add all as role players
         for (int i = 0 ; i < conceptMocks.size(); i++) {
             Concept conceptMock = this.conceptMocks.get(i);
-            this.store.addRolePlayer(conceptMock.asThing().id().toString());
+            Thing thing = conceptMock.asThing();
+            this.store.addRolePlayer(thing.id().toString(), thing.type().label().toString(), relTypeLabel, "somerole");
         }
 
         int relationshipDoubleCounts = this.store.totalRelationshipsRolePlayersOverlap();
@@ -306,7 +299,7 @@ public class IgniteConceptIdStoreTest {
             this.store.addConcept(conceptMock);
         }
         String typeLabel = "person"; // we have 7 mocked people
-        List<String> peopleNotPlayingRoles = this.store.getIdsNotPlayingRole(typeLabel, "friendship", "aRole");
+        List<String> peopleNotPlayingRoles = this.store.getIdsNotPlayingRole(typeLabel, relTypeLabel, "aRole");
         assertEquals(7, peopleNotPlayingRoles.size());
 
     }


### PR DESCRIPTION
To match the new graphs being generated, we also want to track some different statistics, and account for scale differently. Closes #112.

New
* Scale = attribute + explicit relationships + entities
* Track mean In degree (number of roles filled by a concept that stem from an explicit relationship == in degree), mean number of role players of explicit relationships, and mean number of attribute owners ( = number of implicit relationships as well). Depending on the graph, these are expected to be constant or individually increasing as a function of the total scale.

* Continue tracking entity orphans, attribute orphans and relationships that play roles as well as have role players to assess data generation quality.
* New printing of all of these statistics, plus tests for Ignite-based storage of the new data required for this change.