### PR TITLE
New Data Generator Graphs (2/2)

### DIFF
--- a/runner/conf/biochem_network/biochem_network.gql
+++ b/runner/conf/biochem_network/biochem_network.gql
@@ -1,19 +1,19 @@
 define
 
     # fixed increments
-    name sub attribute datatype string;
+    biochem-id sub attribute datatype long;
 
     # fixed increments
     chemical sub entity,
         plays agent,
-        has name; # append uniquely (1 name per chemical)
+        has biochem-id; # append uniquely (1 name per chemical)
 
     # fixed increments
     enzyme sub entity,
         plays catalyst,
-        has name; # append unique (1 per enzyme)
+        has biochem-id; # append unique (1 per enzyme)
 
     # fixed increments
-    interaction sub relationship;
+    interaction sub relationship,
         relates agent, # scale number of agents over time
         relates catalyst; # scale number of catalysts over time

--- a/runner/conf/biochem_network/queries.yml
+++ b/runner/conf/biochem_network/queries.yml
@@ -1,5 +1,5 @@
 queries:
-  - "match $x isa enzyme; get;"
-  - "match $x has $n; $n isa name; get;"
+  - "match $x isa chemical; get;"
+  - "match $x has biochem-id $n; get;"
   - "match $r (agent: $agent); get $agent;"
 

--- a/runner/conf/financial_transactions/financial.gql
+++ b/runner/conf/financial_transactions/financial.gql
@@ -2,17 +2,12 @@ define
 
     # fixed increments
     quantity sub attribute datatype long;
-    #name sub attribute datatype string;
+    # name sub attribute datatype string;
 
     # don't instantiate this
     trader sub entity,
-        plays transactor,
-        has name;
-
-    # scaling increments => graph dominated by entities
-    company sub trader;
-    # scaling increments => graph dominated by entities
-    person sub trader;
+        plays transactor;
+#        has name;
 
     #government sub entity,
     #    plays taxor,
@@ -21,7 +16,8 @@ define
 
     # fixed increments
     transaction sub relationship,
-        relates transactor; # scaling increments => most connections are via role players to few relationships
+        relates transactor,  # scaling increments => most connections are via role players to few relationships
+        has quantity;
     #    plays taxed;
 
 

--- a/runner/conf/financial_transactions/financial_config.yml
+++ b/runner/conf/financial_transactions/financial_config.yml
@@ -3,6 +3,8 @@ schema: "financial.gql"
 queries: "queries.yml"
 scales:
 - 500
+- 750
+- 1000
 repeatsPerQuery: 1
   # TODO
   # concurrency:

--- a/runner/conf/financial_transactions/queries.yml
+++ b/runner/conf/financial_transactions/queries.yml
@@ -1,7 +1,7 @@
 queries:
   - "match $x isa trader; get;"
   # expect to see scale in out degree of name * number of name assuming QP starts at `name` label
-  - "match $x has $n; $n isa name; get;"
+  - "match $x has quantity $n; get;"
   # expect to see scale in role players * number of relationships
-  - "match $r (agent: $agent); $r isa transaction; get $agent;"
+  - "match $r (transactor: $trader); $r isa transaction; get $trader;"
 

--- a/runner/src/pick/CountingStreamGenerator.java
+++ b/runner/src/pick/CountingStreamGenerator.java
@@ -26,21 +26,21 @@ import java.util.stream.Stream;
 /**
  *
  */
-public class IntegerStreamGenerator implements StreamInterface<Integer>{
-    private Random rand;
+public class CountingStreamGenerator implements StreamInterface<Integer>{
+    private int n;
 
-    public IntegerStreamGenerator(Random rand, int lowerBound, int upperBound) {
-        this.rand = rand;
-        this.lowerBound = lowerBound;
-        this.upperBound = upperBound;
+    public CountingStreamGenerator(int start) {
+        this.n = start - 1;
     }
 
-    private int lowerBound;
-    private int upperBound;
+    private int next() {
+        this.n++;
+        return this.n;
+    }
 
     @Override
     public Stream<Integer> getStream(Grakn.Transaction tx) {
-        return rand.ints(lowerBound, upperBound + 1).boxed();
+        return Stream.generate( () -> next());
     }
 
     @Override

--- a/runner/src/pick/StringStreamGenerator.java
+++ b/runner/src/pick/StringStreamGenerator.java
@@ -11,7 +11,7 @@ import java.util.stream.Stream;
 /**
  * adapted from https://stackoverflow.com/questions/41107/how-to-generate-a-random-alpha-numeric-string
  *
- * TODO this has substantial overlap in responsibility with IntegerStreamGenerator ie. StreamInterface<T>
+ * TODO this has substantial overlap in responsibility with CountingStreamGenerator ie. StreamInterface<T>
  */
 public class StringStreamGenerator implements StreamInterface<String> {
 

--- a/runner/src/schemaspecific/BiochemNetworkGenerator.java
+++ b/runner/src/schemaspecific/BiochemNetworkGenerator.java
@@ -1,0 +1,203 @@
+package grakn.benchmark.runner.schemaspecific;
+
+import grakn.benchmark.runner.pick.CountingStreamGenerator;
+import grakn.benchmark.runner.pick.StreamProvider;
+import grakn.benchmark.runner.probdensity.FixedConstant;
+import grakn.benchmark.runner.probdensity.FixedDiscreteGaussian;
+import grakn.benchmark.runner.probdensity.ScalingDiscreteGaussian;
+import grakn.benchmark.runner.storage.ConceptStore;
+import grakn.benchmark.runner.storage.FromIdStorageConceptIdPicker;
+import grakn.benchmark.runner.storage.IdStoreInterface;
+import grakn.benchmark.runner.storage.NotInRelationshipConceptIdPicker;
+import grakn.benchmark.runner.strategy.*;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Random;
+
+public class BiochemNetworkGenerator implements SchemaSpecificDataGenerator {
+
+    private Random random;
+    private ConceptStore storage;
+
+    private RouletteWheel<TypeStrategyInterface> entityStrategies;
+    private RouletteWheel<TypeStrategyInterface> relationshipStrategies;
+    private RouletteWheel<TypeStrategyInterface> attributeStrategies;
+    private RouletteWheel<RouletteWheel<TypeStrategyInterface>> operationStrategies;
+
+    public BiochemNetworkGenerator(Random random, ConceptStore storage) {
+        this.random = random;
+        this.storage = storage;
+
+
+        this.entityStrategies = new RouletteWheel<>(random);
+        this.relationshipStrategies = new RouletteWheel<>(random);
+        this.attributeStrategies = new RouletteWheel<>(random);
+        this.operationStrategies = new RouletteWheel<>(random);
+
+        buildGenerator();
+    }
+
+    private void buildGenerator() {
+        buildStrategies();
+        this.operationStrategies.add(1.0, entityStrategies);
+        this.operationStrategies.add(1.0, relationshipStrategies);
+        this.operationStrategies.add(1.0, attributeStrategies);
+    }
+
+    private void buildStrategies() {
+
+        /*
+        Entities
+         */
+
+        this.entityStrategies.add(
+                1.0,
+                new EntityStrategy(
+                        "chemical",
+                        new FixedDiscreteGaussian(this.random, 8, 4))
+        );
+
+        this.entityStrategies.add(
+                1.0,
+                new EntityStrategy(
+                        "enzyme",
+                        new FixedDiscreteGaussian(this.random, 2, 0.5)
+                )
+        );
+
+        /*
+        Attributes
+         */
+
+        CountingStreamGenerator idGenerator = new CountingStreamGenerator(0);
+        this.attributeStrategies.add(
+                1.0,
+                new AttributeStrategy<>(
+                        "biochem-id",
+                        new FixedDiscreteGaussian(this.random,5,3),
+                        new StreamProvider<>(idGenerator)
+                )
+        );
+
+
+        /*
+        Relationships
+         */
+
+
+        // increasingly large interactions (increasing number of role players)
+        RolePlayerTypeStrategy agentRolePlayer = new RolePlayerTypeStrategy(
+                "agent",
+                "chemical",
+                // high variance in the number of role players
+                new ScalingDiscreteGaussian(random, () -> this.getGraphScale(), 0.01, 0.005),
+                new StreamProvider<>(
+                        new FromIdStorageConceptIdPicker(
+                                random,
+                                (IdStoreInterface) this.storage,
+                                "chemical")
+                )
+        );
+        RolePlayerTypeStrategy catalystRolePlayer = new RolePlayerTypeStrategy(
+                "catalyst",
+                "enzyme",
+                // high variance in the number of role players
+                new ScalingDiscreteGaussian(random, () -> this.getGraphScale(), 0.001, 0.001),
+                new StreamProvider<>(
+                        new FromIdStorageConceptIdPicker(
+                                random,
+                                (IdStoreInterface) this.storage,
+                                "enzyme")
+                )
+        );
+        this.relationshipStrategies.add(
+                3.0,
+                new RelationshipStrategy(
+                        "interaction",
+                        new FixedDiscreteGaussian(this.random, 50, 25),
+                        new HashSet<>(Arrays.asList(agentRolePlayer, catalystRolePlayer))
+                )
+        );
+
+
+        // @has-biochem-id for chemicals
+        RolePlayerTypeStrategy chemicalIdOwner = new RolePlayerTypeStrategy(
+                "@has-biochem-id-owner",
+                "@has-biochem-id",
+                new FixedConstant(1),
+                new StreamProvider<>(
+                        new NotInRelationshipConceptIdPicker(
+                                random,
+                                (IdStoreInterface) storage,
+                                "chemical", "@has-biochem-id", "@has-biochem-id-owner"
+                        )
+                )
+        );
+        RolePlayerTypeStrategy chemicalIdValue = new RolePlayerTypeStrategy(
+                "@has-biochem-id-value",
+                "@has-biochem-id",
+                new FixedConstant(1),
+                new StreamProvider<>(
+                        new NotInRelationshipConceptIdPicker(
+                                random,
+                                (IdStoreInterface) storage,
+                                "biochem-id", "@has-biochem-id", "@has-biochem-id-value"
+                        )
+                )
+        );
+        this.relationshipStrategies.add(
+                1.0,
+                new RelationshipStrategy(
+                        "@has-biochem-id",
+                        new FixedDiscreteGaussian(random, 20, 5), // more than number of entities being created to compensate for being picked less
+                        new HashSet<>(Arrays.asList(chemicalIdOwner, chemicalIdValue))
+                )
+        );
+
+
+        // @has-biochem-id for enzymes
+        RolePlayerTypeStrategy enzymeIdOwner = new RolePlayerTypeStrategy(
+                "@has-biochem-id-owner",
+                "@has-biochem-id",
+                new FixedConstant(1),
+                new StreamProvider<>(
+                        new NotInRelationshipConceptIdPicker(
+                                random,
+                                (IdStoreInterface) storage,
+                                "enzyme", "@has-biochem-id", "@has-biochem-id-owner"
+                        )
+                )
+        );
+        RolePlayerTypeStrategy enzymeIdValue = new RolePlayerTypeStrategy(
+                "@has-biochem-id-value",
+                "@has-biochem-id",
+                new FixedConstant(1),
+                new StreamProvider<>(
+                        new NotInRelationshipConceptIdPicker(
+                                random,
+                                (IdStoreInterface) storage,
+                                "biochem-id", "@has-biochem-id", "@has-biochem-id-value"
+                        )
+                )
+        );
+        this.relationshipStrategies.add(
+                1.0,
+                new RelationshipStrategy(
+                        "@has-biochem-id",
+                        new FixedDiscreteGaussian(random, 20, 5), // more than number of entities being created to compensate for being picked less
+                        new HashSet<>(Arrays.asList(enzymeIdOwner, enzymeIdValue))
+                )
+        );
+    }
+
+    @Override
+    public RouletteWheel<RouletteWheel<TypeStrategyInterface>> getStrategy() {
+        return this.operationStrategies;
+    }
+
+    @Override
+    public ConceptStore getConceptStore() {
+        return this.storage;
+    }
+}

--- a/runner/src/schemaspecific/FinancialTransactionsGenerator.java
+++ b/runner/src/schemaspecific/FinancialTransactionsGenerator.java
@@ -1,0 +1,152 @@
+package grakn.benchmark.runner.schemaspecific;
+
+import grakn.benchmark.runner.pick.CountingStreamGenerator;
+import grakn.benchmark.runner.pick.StreamProvider;
+import grakn.benchmark.runner.probdensity.FixedConstant;
+import grakn.benchmark.runner.probdensity.FixedDiscreteGaussian;
+import grakn.benchmark.runner.probdensity.ScalingDiscreteGaussian;
+import grakn.benchmark.runner.probdensity.ScalingUniform;
+import grakn.benchmark.runner.storage.ConceptStore;
+import grakn.benchmark.runner.storage.FromIdStorageConceptIdPicker;
+import grakn.benchmark.runner.storage.IdStoreInterface;
+import grakn.benchmark.runner.storage.NotInRelationshipConceptIdPicker;
+import grakn.benchmark.runner.strategy.*;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Random;
+
+public class FinancialTransactionsGenerator implements SchemaSpecificDataGenerator{
+
+    private Random random;
+    private ConceptStore storage;
+
+    private RouletteWheel<TypeStrategyInterface> entityStrategies;
+    private RouletteWheel<TypeStrategyInterface> relationshipStrategies;
+    private RouletteWheel<TypeStrategyInterface> attributeStrategies;
+    private RouletteWheel<RouletteWheel<TypeStrategyInterface>> operationStrategies;
+
+    public FinancialTransactionsGenerator(Random random, ConceptStore storage) {
+        this.random = random;
+        this.storage = storage;
+
+
+        this.entityStrategies = new RouletteWheel<>(random);
+        this.relationshipStrategies = new RouletteWheel<>(random);
+        this.attributeStrategies = new RouletteWheel<>(random);
+        this.operationStrategies = new RouletteWheel<>(random);
+
+        buildGenerator();
+    }
+
+    private void buildGenerator() {
+        buildStrategies();
+        this.operationStrategies.add(1.0, entityStrategies);
+        this.operationStrategies.add(1.0, relationshipStrategies);
+        this.operationStrategies.add(1.0, attributeStrategies);
+    }
+
+    private void buildStrategies() {
+
+        /*
+        Entities
+         */
+
+        // SCALING number of entities added!
+        this.entityStrategies.add(
+                1.0,
+                new EntityStrategy(
+                        "trader",
+                        new ScalingDiscreteGaussian(this.random, () -> this.getGraphScale(), 0.05, 0.02))
+        );
+
+
+        /*
+        Attributes
+         */
+
+        // FIXED number of attributes added
+        CountingStreamGenerator idGenerator = new CountingStreamGenerator(0);
+        this.attributeStrategies.add(
+                1.0,
+                new AttributeStrategy<>(
+                        "quantity",
+                        new FixedDiscreteGaussian(this.random,5,3),
+                        new StreamProvider<>(idGenerator)
+                )
+        );
+
+
+        /*
+        Relationships
+         */
+
+        // increasingly large interactions (increasing number of role players)
+        RolePlayerTypeStrategy transactorRolePlayer = new RolePlayerTypeStrategy(
+                "transactor",
+                "trader",
+                // high variance in the number of role players
+                new ScalingDiscreteGaussian(random, () -> this.getGraphScale(), 0.01, 0.005),
+                new StreamProvider<>(
+                        new FromIdStorageConceptIdPicker(
+                                random,
+                                (IdStoreInterface) this.storage,
+                                "trader")
+                )
+        );
+        this.relationshipStrategies.add(
+                1.0,
+                new RelationshipStrategy(
+                        "transaction",
+                        new FixedDiscreteGaussian(this.random, 30, 10), // but fixed number of rels added per iter
+                        new HashSet<>(Arrays.asList(transactorRolePlayer))
+                )
+        );
+
+
+        // @has-quantity on the transaction relationship (1 quantity per transaction)
+        RolePlayerTypeStrategy quantityOwner = new RolePlayerTypeStrategy(
+                "@has-quantity-owner",
+                "@has-quantity",
+                new FixedConstant(1),
+                new StreamProvider<>(
+                        new NotInRelationshipConceptIdPicker(
+                                random,
+                                (IdStoreInterface) storage,
+                                "transaction", "@has-quantity", "@has-quantity-owner"
+                        )
+                )
+        );
+        RolePlayerTypeStrategy quantityValue = new RolePlayerTypeStrategy(
+                "@has-quantity-value",
+                "@has-quantity",
+                new FixedConstant(1),
+                new StreamProvider<>(
+                        new FromIdStorageConceptIdPicker(
+                                random,
+                                (IdStoreInterface) this.storage,
+                                "quantity"
+                        )
+                )
+        );
+        this.relationshipStrategies.add(
+                1.0,
+                new RelationshipStrategy(
+                        "@has-quantity",
+                        new ScalingDiscreteGaussian(random, () -> getGraphScale(), 0.01, 0.005), // more than number of entities being created to compensate for being picked less
+                        new HashSet<>(Arrays.asList(quantityOwner, quantityValue))
+                )
+        );
+
+    }
+
+    @Override
+    public RouletteWheel<RouletteWheel<TypeStrategyInterface>> getStrategy() {
+        return this.operationStrategies;
+    }
+
+    @Override
+    public ConceptStore getConceptStore() {
+        return this.storage;
+    }
+}

--- a/runner/src/schemaspecific/RoadNetworkGenerator.java
+++ b/runner/src/schemaspecific/RoadNetworkGenerator.java
@@ -77,15 +77,6 @@ public class RoadNetworkGenerator implements SchemaSpecificDataGenerator {
         Relationships
          */
 
-
-        // intersection
-        // TODO what we want here is to repeat 5-10 roads not initially in a relationship
-        // and use these to connect to to some number of other roads via intersections
-        // ie. repeat those 5-10 roads that were initially not in a relationship until number of
-        // relationships created is exhausted
-
-        // TODO
-
         RolePlayerTypeStrategy unusedEndpointRoads = new RolePlayerTypeStrategy(
                 "endpoint",
                 "road",

--- a/runner/src/schemaspecific/SchemaSpecificDataGeneratorFactory.java
+++ b/runner/src/schemaspecific/SchemaSpecificDataGeneratorFactory.java
@@ -16,12 +16,6 @@ public class SchemaSpecificDataGeneratorFactory {
                 return new SocialNetworkGenerator(random, storage);
             case "road_network":
                 return new RoadNetworkGenerator(random, storage);
-//            case "societal_model":
-//                return new SocietalModelGenerator(random, storage);
-//            case "societal_model":
-//                return new SocietalModelGenerator(random, storage);
-//            case "societal_model":
-//                return new SocietalModelGenerator(random, storage);
             default:
                 throw new RuntimeException("Unknown specific schema generation strategy name: " + name);
         }

--- a/runner/src/schemaspecific/SchemaSpecificDataGeneratorFactory.java
+++ b/runner/src/schemaspecific/SchemaSpecificDataGeneratorFactory.java
@@ -16,6 +16,10 @@ public class SchemaSpecificDataGeneratorFactory {
                 return new SocialNetworkGenerator(random, storage);
             case "road_network":
                 return new RoadNetworkGenerator(random, storage);
+            case "biochem_network":
+                return new BiochemNetworkGenerator(random, storage);
+            case "financial":
+                return new FinancialTransactionsGenerator(random, storage);
             default:
                 throw new RuntimeException("Unknown specific schema generation strategy name: " + name);
         }

--- a/runner/src/schemaspecific/SocialNetworkGenerator.java
+++ b/runner/src/schemaspecific/SocialNetworkGenerator.java
@@ -10,7 +10,6 @@ import grakn.benchmark.runner.storage.ConceptStore;
 import grakn.benchmark.runner.storage.FromIdStorageConceptIdPicker;
 import grakn.benchmark.runner.storage.IdStoreInterface;
 import grakn.benchmark.runner.strategy.*;
-import org.apache.ignite.IgniteDataStreamer;
 
 import java.util.Arrays;
 import java.util.HashSet;

--- a/runner/src/schemaspecific/SocietalModelGenerator.java
+++ b/runner/src/schemaspecific/SocietalModelGenerator.java
@@ -3,13 +3,11 @@ package grakn.benchmark.runner.schemaspecific;
 import grakn.benchmark.runner.probdensity.*;
 import grakn.benchmark.runner.pick.CentralStreamProvider;
 import grakn.benchmark.runner.storage.FromIdStorageConceptIdPicker;
-import grakn.benchmark.runner.pick.IntegerStreamGenerator;
 import grakn.benchmark.runner.pick.NotInRelationshipConceptIdStream;
 import grakn.benchmark.runner.pick.PickableCollectionValuePicker;
 import grakn.benchmark.runner.pick.StreamProvider;
 import grakn.benchmark.runner.storage.ConceptStore;
 import grakn.benchmark.runner.storage.IdStoreInterface;
-import grakn.benchmark.runner.strategy.AttributeOwnerTypeStrategy;
 import grakn.benchmark.runner.strategy.AttributeStrategy;
 import grakn.benchmark.runner.strategy.EntityStrategy;
 import grakn.benchmark.runner.strategy.RelationshipStrategy;
@@ -216,7 +214,7 @@ public class SocietalModelGenerator implements SchemaSpecificDataGenerator {
 //                                )
 //                        ),
 //                        new StreamProvider<>(
-//                                new IntegerStreamGenerator(random, 0, 100)
+//                                new CountingStreamGenerator(random, 0, 100)
 //                        )
 //                )
 //        );
@@ -237,7 +235,7 @@ public class SocietalModelGenerator implements SchemaSpecificDataGenerator {
 //                                )
 //                        ),
 //                        new StreamProvider<>(
-//                                new IntegerStreamGenerator(random, 0, 1000000)
+//                                new CountingStreamGenerator(random, 0, 1000000)
 //                        )
 //                )
 //        );
@@ -258,7 +256,7 @@ public class SocietalModelGenerator implements SchemaSpecificDataGenerator {
 //                                )
 //                        ),
 //                        new StreamProvider<>(
-//                                new IntegerStreamGenerator(random, 1, 10)
+//                                new CountingStreamGenerator(random, 1, 10)
 //                        )
 //                )
 //        );

--- a/runner/src/storage/NotInRelationshipConceptIdPicker.java
+++ b/runner/src/storage/NotInRelationshipConceptIdPicker.java
@@ -14,12 +14,12 @@ public class NotInRelationshipConceptIdPicker extends FromIdStoragePicker<Concep
 
     public NotInRelationshipConceptIdPicker(Random rand,
                                             IdStoreInterface conceptStore,
-                                            String typeLabel,
+                                            String rolePlayerTypeLabel,
                                             String relationshipLabel,
                                             String roleLabel
                                             ) {
-        super(rand, conceptStore, typeLabel);
-        this.typeLabel = typeLabel;
+        super(rand, conceptStore, rolePlayerTypeLabel);
+        this.typeLabel = rolePlayerTypeLabel;
         this.relationshipLabel = relationshipLabel;
         this.roleLabel = roleLabel;
 

--- a/runner/src/strategy/RolePlayerTypeStrategy.java
+++ b/runner/src/strategy/RolePlayerTypeStrategy.java
@@ -30,8 +30,8 @@ public class RolePlayerTypeStrategy extends TypeStrategy implements HasPicker {
     private final String roleLabel;
     private StreamProviderInterface<ConceptId> conceptPicker;
 
-    public RolePlayerTypeStrategy(String roleLabel, String typeLabel, ProbabilityDensityFunction numInstancesPDF, StreamProviderInterface<ConceptId> conceptPicker) {
-        super(typeLabel, numInstancesPDF);
+    public RolePlayerTypeStrategy(String roleLabel, String relationshipLabel, ProbabilityDensityFunction numInstancesPDF, StreamProviderInterface<ConceptId> conceptPicker) {
+        super(relationshipLabel, numInstancesPDF);
         this.roleLabel = roleLabel;
         this.conceptPicker = conceptPicker;
     }


### PR DESCRIPTION
Implement the data generators for financial transactions and biological data.
These address the following two cases:

Financial transactions: 
* Increasing large transaction relationships with more and more role players (companies). Companies are inserted with increasing quantity as well, so the mean degree of companies is constant. Add quantities to the transaction relationships (1 per relationship), but these need not be unique across transactions
* Biological network: scale role players in `interactions`, but not the number of entities being generated. This should increase the mean degree of entities over scale, as well as mean number of role players in a relationship (out degree)

Data generator parameters probably still require some tuning. 
Also some small changes in variable names and generators. 