### PR TITLE
New Readme's

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Grakn Benchmark
 
-This repository contains components used benchmarking and profiling Grakn.
+This repository contains components used for benchmarking and profiling Grakn.
 * `common`: shared configurations and entry points for `profiler` and `report`
 * `generator`: the Grakn data generator that can be used to populate a keyspace in a sophisticated manner, with configurable distributions of each type and relations
 * `lib`: classes that implement Zipkin tracing for the server and Grakn Java client. Pulled in by `grakn core` and clients that have tracing enabled.
@@ -8,29 +8,3 @@ This repository contains components used benchmarking and profiling Grakn.
 * `profiler`: the core of `benchmark-ci` that takes scenarios, generates data, and profiles queries being executed into Elasticsearch using Zipkin tracing.
 * `report`: a very simplified version of `benchmark-ci` without tracing that measures high level performance of Grakn from the client side and can compile a report as a text file.
 * `service`: the dashboard and scripts required to run `benchmark-ci`.
-
-
-
-Benchmark is a piece of software used for generating data and measuring the performance of Grakn. It is composed of two main components:
-
-1. *Profiler*, used to run one of the following use cases (accessed using the `profiler` package):
-
-       
-2. *Benchmark Service*, (accessed using the `service` package), which can be used to: 
-    * Spin up a GCP instance that listens to commits on a specific repository (configused using Github web hooks)
-    * Launch the Profiler and benchmark commits/PRs to the repository
-    * Visualise tracing and other data recorded into ElasticSearch by Zipkin in a web dashboard hosted by the GCP instance
-
-
-
-
-
-Further examples:
-
-#### Adding new spans to measure code segments
-
-- On the server, the intended usage is as follows:
-
-Then add a child span that propagates in thread-local storage
-
-

--- a/README.md
+++ b/README.md
@@ -1,85 +1,29 @@
-# Benchmark
+# Grakn Benchmark
+
+This repository contains components used benchmarking and profiling Grakn.
+* `common`: shared configurations and entry points for `profiler` and `report`
+* `generator`: the Grakn data generator that can be used to populate a keyspace in a sophisticated manner, with configurable distributions of each type and relations
+* `lib`: classes that implement Zipkin tracing for the server and Grakn Java client. Pulled in by `grakn core` and clients that have tracing enabled.
+* `metric`: implementations of various more complex graph analysis metrics, compatible with Grakn or standard graphs fed from files (currently not used)
+* `profiler`: the core of `benchmark-ci` that takes scenarios, generates data, and profiles queries being executed into Elasticsearch using Zipkin tracing.
+* `report`: a very simplified version of `benchmark-ci` without tracing that measures high level performance of Grakn from the client side and can compile a report as a text file.
+* `service`: the dashboard and scripts required to run `benchmark-ci`.
+
+
 
 Benchmark is a piece of software used for generating data and measuring the performance of Grakn. It is composed of two main components:
 
 1. *Profiler*, used to run one of the following use cases (accessed using the `profiler` package):
 
-       1. [With Data Generation] Generate hypergraphs to different scales and profile performances  
-
-       2. [Without Data Generation] Profile an existing graph in a keyspace (without committing profiled queries)
-       
-       3. [Without Data Generation] Profile an empty keyspace that evolves as profiled queries are committed
        
 2. *Benchmark Service*, (accessed using the `service` package), which can be used to: 
     * Spin up a GCP instance that listens to commits on a specific repository (configused using Github web hooks)
     * Launch the Profiler and benchmark commits/PRs to the repository
     * Visualise tracing and other data recorded into ElasticSearch by Zipkin in a web dashboard hosted by the GCP instance
 
-## Requirements
-
-1. [Download Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/6.3/zip-targz.html)
-
-2. [Download Zipkin](https://github.com/openzipkin/zipkin/blob/master/zipkin-server/README.md)
-
-3. Install `pipenv` (for dashboard)
-
-4. Install the requirements of `benchmark-dashboard`: 
-
-   ```
-   $ cd $BENCHMARK/dashboard
-   $ pipenv install
-   ```
-
-## Quickstart
-
-We use temporary helper scripts to start Benchmark from scratch on a local machine:
-
- 1. `external-dependencies/setup.sh` will download and start Elasticsearch and Zipkin
- 2. `./benchmark --config=path-to-config` will start generating data and profiling graph at different scales
- 3. `./benchmark --no-data-generation -k an-existing-keyspace-name` will profile an existing keyspace, skipping the data generation
-
-NOTE: for the time being you will need to manually kill Elasticsearch and Zipkin once you're done with benchmakring. (`jps` followed by `kill ...` should do)
-
-## Using Benchmark
-
-### 1. Start Elasticsearch & Zipkin
-
-In the Elasticsearch installation directory, do:
-```
-$ ./bin/elasticsearch -E path.logs=<REPOSITORY_PATH>/data/elasticsearch/logs -E path.data=<REPOSITORY_PATH>/data/data/elasticsearch/
-```
-
-Check if Elasticsearch is running by accessing http://localhost:9200 from the browser.
-
-In the Zipkin installation directory, do:
-
-```
-$ STORAGE_TYPE=elasticsearch ES_HOSTS=http://localhost:9200 ES_INDEX="benchmark" java -jar zipkin.jar
-```
-Check if Zipkin is running by accessing http://localhost:9411/zipkin/ from the browser.
-
-**NOTE**: For development purpose, you may find it easier to start Zipkin backed with an in-memory store as opposed to ElasticSearch:
-
-```
-$ java -jar zipkin.jar
-```
 
 
 
-### 2. Benchmark With GraknBenchmark
-
-We define YAML config files to execute under `benchmark/conf/somedir`
-
-The entry point to rebuild, generate, and name executions of config files is `run.py`
-
-Basic usage:
-
-`benchmark --config grakn-benchmark/src/main/resources/societal_config_1.yml --execution-name query-plan-mod-1 --keyspace benchmark` 
-
-Notes:
-
-- Naming the execution not required, default name is always prepended with current Date and `name` tag in the YAML file
-- Keyspace is not required, defaults to `name` in the YAML file
 
 Further examples:
 
@@ -87,49 +31,6 @@ Further examples:
 
 - On the server, the intended usage is as follows:
 
-Then add a child span that propogates in thread-local storage
-
-```
-    ScopedSpan childSpan = null;
-    if (ServerTracingInstrumentation.tracingActive()) {
-        childSpan = ServerTracingInstrumentation.createScopedChildSpan("newchild");
-    }
-    ...
-    ... code to time/instrument further ...
-    ...
-    if (childSpan != null) {
-        childSpan.finish();
-    }
-```
-
-Some packages in `grakn.core` are not currently depending on `benchmark.lib` which contains the instrumentation.
-In the `dependencies.yaml` make sure
-
-```
-ai.grakn:
-    benchmark.lib:
-        version: ...
-        lang: java
-```
-
-is present, and in the BUILD file this dependency is referenced.
-
-
-
-### 3. Visualise Results In Benchmark-Dashboard
-
-NOTE: This dashboard is the first version produced to visualize our tracing results from Zipkin.
-The last expected compatible version of `benchmark` is ec2272bb2f614a424de4498e968e5b1a7497c32a
-After this, the structure of spans has changed (eg. no more `batchSpan`, change order query repetitions)
-
-The visualisation dashboard reads ElasticSearch and creates graphs via Dash and Plotly.
-
-Getting it up and running requires `pipenv` and Python >=3.6.0
-
-1. `pipenv shell` (may need to modify the `python_version = "3.6"` if the python version is newer/not quite the same. Alternatively manage the python version with `pyenv`.
-2. In the `dashboard/` directory, run `python dashboard.py`
-3. Navigate to `http:localhost:8050` to see the dashboard
-
-The box plots are individually clickable to drill down, bar charts (default if only 1 repetition is being displayed) cycle through drill downs on each click.
+Then add a child span that propagates in thread-local storage
 
 

--- a/common/configuration/scenario/road_network/road_config_read.yml
+++ b/common/configuration/scenario/road_network/road_config_read.yml
@@ -3,7 +3,7 @@ description: "Road network reads with: Constant C_in, Constant R_out, Constant A
 dataGenerator: "road_network"
 schema: "road_network.gql"
 scales:
-  - 1000
+  - 2000
   - 4000
   - 8000
 

--- a/generator/README.md
+++ b/generator/README.md
@@ -1,0 +1,14 @@
+# Data Generator
+
+The Grakn-specific data generator for creating complex hypergraphs dynamically.
+
+## Usage
+The library is intended to be used coupled with other entry points. The main operation
+that can be called is `generate(limit)`, which writes to the indicated keyspace
+until the scale of the hypergraph exceeds the given limit.
+
+The constructor also takes in a parameter `dataGenerator`, which selects
+which `definition` is used to generate the graph. The definition is a manually-written
+specification of how many of each type of entity, relationship and attribute to 
+generate, and how to connect them.
+

--- a/profiler/README.md
+++ b/profiler/README.md
@@ -1,0 +1,55 @@
+# Grakn Profiler
+
+`profiler` is used to measure performance of code regions within Grakn in an extensible and visualisable way.
+
+## High level usage
+Input: scenarios specified by `config.yml` files (see `//common/configuration/scenario` for samples)
+
+Output: Spans (timing blocks) created by instrumentation points within the Java client and the Grakn
+server are recorded in Elasticsearch. These can be visualised using the dashboard in `//service`,
+or in raw format in Zipkin's own web dashboard (port 9411).
+
+
+## Running locally (not via benchmark-ci)
+1. Build the benchmark profiler distribution (`bazel build //:profiler-distribution`)
+
+2. In the unzipped distribution `external-dependencies/setup.sh` will download and start Elasticsearch and Zipkin
+2. Unzip the target, and run `setup.sh` which should download and install Elasticsearch and Zipkin locally
+=> Check if Zipkin is running by accessing http://localhost:9411/zipkin/ from the browser.
+3. Ensure Grakn server is running *with the `--benchmark` flag*
+4. In the unzipped target, run `./benchmark --config=path/to/scenario/config --execution-name=<some unique name> ... <optional args>`
+
+
+## Use cases and options
+1. [With Data Generation] Generate hypergraphs to different scales and profile performance
+
+2. [Without Data Generation] Profile an existing graph in a keyspace 
+
+3. [Without Data Generation] Profile an empty keyspace that evolves as profiled queries are committed
+
+
+## Adding Tracing Points
+
+The basic component of tracing is called a Span. Spans are a component of 
+Zipkin which can be nested hierarchically to create trees of execution time, 
+allowing us to inspect the breakdown of code that has been instrumented.
+
+On the Grakn Server, tracing is exposed via the `ServerTracing` class,
+and should be used as follows:
+
+```
+ScopedSpan span = null;
+if (ServerTracing.tracingActive()) {
+    childSpan = ServerTracing.startScopedChildSpan("name");
+}
+...
+... code to time/instrument further ...
+...
+if (span != null) {
+    span.finish();
+}
+```
+
+It's important not to forget to call `span.finish()` on all possible exit paths, otherwise
+the hierarchy of spans may be assembled incorrectly. It may be necessary to combine this with `try/catch/finally`
+in some cases where exceptions can lead to unexpected exit paths.

--- a/profiler/README.md
+++ b/profiler/README.md
@@ -27,6 +27,11 @@ or in raw format in Zipkin's own web dashboard (port 9411).
 
 3. [Without Data Generation] Profile an empty keyspace that evolves as profiled queries are committed
 
+Further, scenario configuration YAML files offer options such as:
+* concurrency - how many concurrent sessions to use, and whether they each use the same keyspace or not
+* scales - what graph scales to profile at
+* deleting inserted concepts - this can be enabled or disabled, as well as whether deletion should be profiled as well
+* optionally comitting queries
 
 ## Adding Tracing Points
 

--- a/report/README.md
+++ b/report/README.md
@@ -1,0 +1,22 @@
+# Report Generator
+
+The report generator is a stripped down subset of `profiler`, without Zipkin tracing.
+
+The goal is do high level timing from the client side, in a realistic setting and automatically generate a performance report.
+
+There are two packages:
+1. `producer` - contains a script `gcp_report.sh` which spawns client and server machines in GCP.
+The client produces a `json` file for each scenario it executes, which are aggregated into a single
+json file and pulled back onto the machine running `gcp_report.sh`
+2. `formatter` - The raw `json` file from the `producer` can be fed into the `formatter` to produce a formatted
+text file report, sorted by query
+
+### Producer
+In `producer`, launch with `./gcp_report.sh`, then wait until `report.json` turns up in the same directory and script terminates.
+
+If an error occurs, the `report.json` may actually be a log file from the client.
+
+### Formatter
+Run directly with bazel:
+
+```bazel run //report/formatter:report-formatter-binary -- --rawReport /abs/path/to/raw/report.json --destination /abs/path/to/output/folder```

--- a/report/producer/gcp_client_server.sh
+++ b/report/producer/gcp_client_server.sh
@@ -19,9 +19,8 @@ fi
 
 GRAKN_URI=$1
 
-git clone https://github.com/flyingsilverfin/benchmark.git
+git clone https://github.com/graknlabs/benchmark.git
 cd benchmark
-git checkout concurrent-report-clients
 
 bazel build //:report-producer-distribution
 cd bazel-genfiles


### PR DESCRIPTION
Clean up and split README's. Top level `benchmark` readme now offers a high level explanation of each sub-package, whereas the inner README's offer some more information.