### PR TITLE
Refactor of ServerTracing

### DIFF
--- a/lib/instrumentation/ServerTracing.java
+++ b/lib/instrumentation/ServerTracing.java
@@ -18,16 +18,19 @@
 
 package grakn.benchmark.lib.instrumentation;
 
-import grakn.benchmark.lib.util.GrpcMessageConversion;
 import brave.ScopedSpan;
+import brave.Span;
 import brave.Tracer;
 import brave.Tracing;
 import brave.propagation.TraceContext;
-import brave.Span;
+import grakn.benchmark.lib.util.GrpcMessageConversion;
+import grakn.core.protocol.SessionProto;
 import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.urlconnection.URLConnectionSender;
 
-import grakn.core.protocol.SessionProto;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 
 /**
@@ -35,6 +38,9 @@ import grakn.core.protocol.SessionProto;
  * whereas the others may be used my multiple threads in the case of concurrent transactions
  */
 public class ServerTracing {
+
+    private static final Map<Integer, ScopedSpan> openSpans = new ConcurrentHashMap<>();
+    private static final AtomicInteger currentSpanId = new AtomicInteger();
 
     public static void initInstrumentation(String tracingServiceName) {
         // create a Zipkin reporter for the whole server
@@ -51,6 +57,7 @@ public class ServerTracing {
 
     /**
      * Determine if tracing is enabled at all on the server
+     *
      * @return
      */
     public static boolean tracingEnabled() {
@@ -59,6 +66,7 @@ public class ServerTracing {
 
     /**
      * Retrieves the current active Span (thread-local)
+     *
      * @return
      */
     public static Span currentSpan() {
@@ -75,6 +83,7 @@ public class ServerTracing {
     /**
      * Determine if tracing is enabled on the server
      * and the received message contains a TraceContext transmitted in the metadata fields
+     *
      * @param message
      * @return
      */
@@ -95,9 +104,7 @@ public class ServerTracing {
     }
 
 
-
     /**
-     *
      * @param spanName
      * @param parentContext
      * @return A new Span with the given parent Context, NOT thread-local and NOT `.start()`-ed
@@ -110,7 +117,6 @@ public class ServerTracing {
     }
 
     /**
-     *
      * @param spanName
      * @param parentContext
      * @return A new started ScopedSpan with the given parent Context (ie. one that is thread-local, `.start()` already has been called on it)
@@ -124,6 +130,7 @@ public class ServerTracing {
     /**
      * Looks up the current Span in thread-local storage, then creates a new child span on it with the given name
      * that is NOT thread-local nor started.
+     *
      * @param spanName
      * @return
      */
@@ -135,11 +142,38 @@ public class ServerTracing {
     /**
      * Looks up the current Span in thread-local storage, create a new scoped child span with the given name
      * that IS thread-local AND has been started.
+     * Store the scopedSpan in map associated to a unique ID.
+     *
      * @param spanName
-     * @return
+     * @return unique ID that will be used to finish the span
      */
-    public static ScopedSpan startScopedChildSpan(String spanName) {
+    public static Integer startScopedChildSpan(String spanName) {
+        if (!tracingActive()) return null;
+
         Span currentSpan = currentSpan();
-        return startScopedChildSpanWithParentContext(spanName, currentSpan.context());
+        ScopedSpan scopedSpan = startScopedChildSpanWithParentContext(spanName, currentSpan.context());
+        int spanId = currentSpanId.incrementAndGet();
+        openSpans.put(spanId, scopedSpan);
+        return spanId;
+    }
+
+    /**
+     * Finishes scopedSpan associated to spanId and removes it from in-memory map
+     * @param spanId unique ID that will be used to finish the span
+     */
+
+    public static void closeScopedChildSpan(int spanId) {
+        if (!tracingActive()) return;
+
+        ScopedSpan scopedSpan = openSpans.remove(spanId);
+        scopedSpan.finish();
+    }
+
+    /**
+     * This will be used by tests to verify that there are no spans unfinished.
+     * @return true if all spans have been finished, else otherwise
+     */
+    public boolean allSpansFinished(){
+        return openSpans.isEmpty();
     }
 }

--- a/lib/instrumentation/ServerTracing.java
+++ b/lib/instrumentation/ServerTracing.java
@@ -144,6 +144,8 @@ public class ServerTracing {
      * that IS thread-local AND has been started.
      * Store the scopedSpan in map associated to a unique ID.
      *
+     * This also checks if tracing is active, if not, do nothing.
+     *
      * @param spanName
      * @return unique ID that will be used to finish the span
      */
@@ -159,6 +161,9 @@ public class ServerTracing {
 
     /**
      * Finishes scopedSpan associated to spanId and removes it from in-memory map
+     *
+     * This also checks if tracing is active, if not, do nothing.
+     *
      * @param spanId unique ID that will be used to finish the span
      */
 

--- a/profiler/README.md
+++ b/profiler/README.md
@@ -43,16 +43,11 @@ On the Grakn Server, tracing is exposed via the `ServerTracing` class,
 and should be used as follows:
 
 ```
-ScopedSpan span = null;
-if (ServerTracing.tracingActive()) {
-    childSpan = ServerTracing.startScopedChildSpan("name");
-}
+int spanId = ServerTracing.startScopedChildSpan("name");
 ...
 ... code to time/instrument further ...
 ...
-if (span != null) {
-    span.finish();
-}
+ServerTracing.closeScopedChildSpan(spanId);
 ```
 
 It's important not to forget to call `span.finish()` on all possible exit paths, otherwise


### PR DESCRIPTION
Closes https://github.com/graknlabs/benchmark/issues/164

Changes:
Store all child spans in a static map in ServerTracing
static final Map<String, Span> openedSpans = new ConcurrentHashMap<>();

and use atomic integer to always provide unique ids
static final AtomicInteger spanId = new AtomicInteger();

and move logic inside this component to check whether tracing is active.