### PR TITLE
Track time spent on Generation/Querying/Other and bump deps

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,10 +22,9 @@ workspace(name = "benchmark")
 # Grakn Labs dependencies #
 ###########################
 
-load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_grakn_core", "graknlabs_build_tools", "graknlabs_graql", "graknlabs_client_java")
+load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_grakn_core", "graknlabs_build_tools", "graknlabs_client_java")
 graknlabs_build_tools()
 graknlabs_grakn_core()
-graknlabs_graql()
 graknlabs_client_java()
 
 load("@graknlabs_build_tools//distribution:dependencies.bzl", "graknlabs_bazel_distribution")
@@ -89,6 +88,8 @@ graknlabs_benchmark_maven_dependencies()
 load("@graknlabs_build_tools//bazel:dependencies.bzl", "bazel_rules_docker")
 bazel_rules_docker()
 
+load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl", "graknlabs_graql")
+graknlabs_graql()
 
 ###########################
 # Load Graql dependencies #

--- a/common/analysis/test/InsertQueryAnalyserTest.java
+++ b/common/analysis/test/InsertQueryAnalyserTest.java
@@ -96,9 +96,9 @@ public class InsertQueryAnalyserTest {
         String zId = "Vz";
 
         Variable r = new Variable("r");
-        Variable x = new Variable("x").asUserDefined();
-        Variable y = new Variable("y").asUserDefined();
-        Variable z = new Variable("z").asUserDefined();
+        Variable x = new Variable("x").asReturnedVar();
+        Variable y = new Variable("y").asReturnedVar();
+        Variable z = new Variable("z").asReturnedVar();
 
         HashMap<Variable, String> vars = new HashMap<>();
         vars.put(r, rId);
@@ -132,9 +132,9 @@ public class InsertQueryAnalyserTest {
         String zId = "Vz";
 
         Variable r = new Variable("r");
-        Variable x = new Variable("x").asUserDefined();
-        Variable y = new Variable("y").asUserDefined();
-        Variable z = new Variable("z").asUserDefined();
+        Variable x = new Variable("x").asReturnedVar();
+        Variable y = new Variable("y").asReturnedVar();
+        Variable z = new Variable("z").asReturnedVar();
 
         HashMap<Variable, String> vars = new HashMap<>();
         vars.put(r, rId);
@@ -166,8 +166,8 @@ public class InsertQueryAnalyserTest {
 
         String cAttr = "c-name";
 
-        Variable x = new Variable("x").asUserDefined();
-        Variable y = new Variable("y").asUserDefined();
+        Variable x = new Variable("x").asReturnedVar();
+        Variable y = new Variable("y").asReturnedVar();
 
         HashMap<Variable, String> vars = new HashMap<>();
         vars.put(x, xId);
@@ -190,8 +190,8 @@ public class InsertQueryAnalyserTest {
 
         String cAttr = "c-name";
 
-        Variable x = new Variable("x").asUserDefined();
-        Variable y = new Variable("y").asUserDefined();
+        Variable x = new Variable("x").asReturnedVar();
+        Variable y = new Variable("y").asReturnedVar();
 
         HashMap<Variable, String> vars = new HashMap<>();
         vars.put(x, xId);
@@ -209,8 +209,8 @@ public class InsertQueryAnalyserTest {
 
     @Test
     public void whenInsertRelationship_identifyRolePlayers() {
-        Variable xVar = new Variable("x").asUserDefined();
-        Variable yVar = new Variable("y").asUserDefined();
+        Variable xVar = new Variable("x").asReturnedVar();
+        Variable yVar = new Variable("y").asReturnedVar();
         Statement x = var(xVar).id("V123");
         Statement y = var(yVar).id("V234");
         GraqlInsert insertQuery = Graql.match(x, y).insert(var("r").rel("friend", x).rel("friend", y).isa("friendship"));
@@ -233,8 +233,8 @@ public class InsertQueryAnalyserTest {
 
     @Test
     public void whenInsertNonRelationship_returnEmptySet() {
-        Variable x = new Variable("x").asUserDefined();
-        Variable y = new Variable("y").asUserDefined();
+        Variable x = new Variable("x").asReturnedVar();
+        Variable y = new Variable("y").asReturnedVar();
         GraqlInsert insertQuery = Graql.insert(var(x).isa("company").has("name", var(y)).id("V123"), var(y).val("john"));
 
         ConceptMap map = mock(ConceptMap.class);
@@ -251,8 +251,8 @@ public class InsertQueryAnalyserTest {
 
     @Test
     public void whenRelationshipInserted_relationshipLabelFound() {
-        Statement x = var( new Variable("x").asUserDefined()).id("V123");
-        Statement y = var(new Variable("y").asUserDefined()).id("V234");
+        Statement x = var( new Variable("x").asReturnedVar()).id("V123");
+        Statement y = var(new Variable("y").asReturnedVar()).id("V234");
         GraqlInsert insertQuery = Graql.match(x, y).insert(var("r").rel("friend", x).rel("friend", y).isa("friendship"));
         String relationshipLabel = InsertQueryAnalyser.getRelationshipTypeLabel(insertQuery);
         assertEquals("friendship", relationshipLabel);
@@ -260,8 +260,8 @@ public class InsertQueryAnalyserTest {
 
     @Test
     public void whenNoRelationshipInserted_nullReturned() {
-        Statement x = var( new Variable("x").asUserDefined());
-        Statement y = var(new Variable("y").asUserDefined());
+        Statement x = var( new Variable("x").asReturnedVar());
+        Statement y = var(new Variable("y").asReturnedVar());
         GraqlInsert insertQuery = Graql.insert(x.isa("company").has("name", y).id("V123"), y.val("john"));
         String relationshipLabel = InsertQueryAnalyser.getRelationshipTypeLabel(insertQuery);
         assertEquals(null, relationshipLabel);
@@ -269,7 +269,7 @@ public class InsertQueryAnalyserTest {
 
     @Test
     public void whenSameConceptPlaysTwoRoles_conceptRolePairReturnedTwice() {
-        Variable xVar = new Variable("x").asUserDefined();
+        Variable xVar = new Variable("x").asReturnedVar();
         Statement x = var(xVar).id("V123");
         GraqlInsert insertQuery = Graql.match(x).insert(var("r").rel("friend", x).rel("friend", x).isa("friendship"));
 

--- a/common/timer/BUILD
+++ b/common/timer/BUILD
@@ -1,0 +1,23 @@
+#
+#  GRAKN.AI - THE KNOWLEDGE GRAPH
+#  Copyright (C) 2019 Grakn Labs Ltd
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as
+#  published by the Free Software Foundation, either version 3 of the
+#  License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+java_library(
+    name = "timer",
+    srcs = ["BenchmarkingTimer.java"],
+    visibility = ["//visibility:public"]
+)

--- a/common/timer/BenchmarkingTimer.java
+++ b/common/timer/BenchmarkingTimer.java
@@ -1,0 +1,53 @@
+package grakn.benchmark.common.timer;
+
+/**
+ * A small timing class for tracking the proportion of time spent on:
+ * insert data (growing the graph)
+ * doing the profiling/recording of queries on the graphs
+ * other (this includes time to create queries and processing in ignite)
+ */
+public class BenchmarkingTimer {
+
+    private long generateAndProfileStartTime;
+
+    private long totalDataGeneratorQueryTime = 0;
+    private long startDataGeneratorQueryTime;
+
+    private long totalProfilingTime = 0;
+    private long startProfilingTime;
+
+    public void startGenerateAndTrack() {
+        generateAndProfileStartTime = now();
+    }
+
+    public void startDataGeneratorQuery() {
+        startDataGeneratorQueryTime = now();
+    }
+
+    public void endDataGeneratorQuery() {
+        totalDataGeneratorQueryTime += (now() - startDataGeneratorQueryTime);
+    }
+
+    public void startQueryTimeTracking() {
+        startProfilingTime = now();
+    }
+
+    public void endQueryTimeTracking() {
+        totalProfilingTime += (now() - startProfilingTime);
+    }
+
+    public void printTimings() {
+        long totalElapsedMillis = now() - generateAndProfileStartTime;
+        double fractionElapsedDataInsert = (double) totalDataGeneratorQueryTime / totalElapsedMillis;
+        double fractionProfilingTime = (double) totalProfilingTime/ totalElapsedMillis;
+        double fractionRemaining = (double) (totalElapsedMillis - totalProfilingTime - totalDataGeneratorQueryTime)/totalElapsedMillis;
+
+        System.out.printf("Total elapsed time: %d ms, [%.2f data insert, %.2f record/profile, %.2f other (query generation etc.)]\n",
+                totalElapsedMillis, fractionElapsedDataInsert, fractionProfilingTime, fractionRemaining);
+    }
+
+
+    private long now() {
+        return System.currentTimeMillis();
+    }
+}

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -19,30 +19,23 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 
-def graknlabs_graql():
-     git_repository(
-         name = "graknlabs_graql",
-         remote = "https://github.com/graknlabs/graql",
-         commit = "2fc89c3ecaf78da440aebea215f122ed77764005",
-     )
-
 def graknlabs_client_java():
      git_repository(
          name = "graknlabs_client_java",
          remote = "https://github.com/graknlabs/client-java",
-         commit = "791141bbc8a80aba3366b3a17a90f6aad186424d",
+         commit = "f672292a92d004585d54d08c5b9c9eb28c5626c5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
      )
 
 def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "f08f7145dcd408fe80e1e796383094c02d2eafb5" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "8700af4d082b40ca4a115a12479bdc6ab22d6f62", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "d2be22150c8ca386162e0c49d3f82785a11e8d98", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "05ad27318aa97bd4ba2182e48b37ded068e95e2a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )

--- a/generator/BUILD
+++ b/generator/BUILD
@@ -2,6 +2,7 @@ java_library(
     name = "data-generator",
     srcs = glob(["**/*.java", "*.java"]),
     deps = [
+        "//common/timer:timer",
 
         "@graknlabs_client_java//:client-java",
         "@graknlabs_grakn_core//api:api",

--- a/generator/DataGenerator.java
+++ b/generator/DataGenerator.java
@@ -49,17 +49,19 @@ public class DataGenerator {
     private final String dataGenerator;
     private final QueryProvider queryProvider;
     private final ConceptStorage storage;
+    private final BenchmarkingTimer timer;
 
     private int iteration;
 
 
-    public DataGenerator(GraknClient client, String keyspace, ConceptStorage storage, String dataGenerator, QueryProvider queryProvider) {
+    public DataGenerator(GraknClient client, String keyspace, ConceptStorage storage, String dataGenerator, QueryProvider queryProvider, BenchmarkingTimer timer) {
         this.client = client;
         this.keyspace = keyspace;
         this.dataGenerator = dataGenerator;
         this.queryProvider = queryProvider;
         this.iteration = 0;
         this.storage = storage;
+        this.timer = timer;
     }
 
     /**
@@ -68,7 +70,7 @@ public class DataGenerator {
      *
      * @param graphScaleLimit
      */
-    public void generate(int graphScaleLimit, BenchmarkingTimer timer) {
+    public void generate(int graphScaleLimit) {
 
         GraknClient.Session session = client.session(keyspace);
 
@@ -79,7 +81,7 @@ public class DataGenerator {
                 Iterator<GraqlInsert> queryStream = queryProvider.nextQueryBatch();
 
                 // execute & parse the results
-                processQueryStream(queryStream, tx, timer);
+                processQueryStream(queryStream, tx);
 
                 printProgress();
                 tx.commit();
@@ -91,7 +93,7 @@ public class DataGenerator {
         System.out.print("\n");
     }
 
-    private void processQueryStream(Iterator<GraqlInsert> queryIterator, GraknClient.Transaction tx, BenchmarkingTimer timer) {
+    private void processQueryStream(Iterator<GraqlInsert> queryIterator, GraknClient.Transaction tx) {
         /*
         Make the data insertions from the stream of queries generated
          */

--- a/generator/query/AttributeGenerator.java
+++ b/generator/query/AttributeGenerator.java
@@ -61,7 +61,7 @@ public class AttributeGenerator<Datatype> implements QueryGenerator {
             @Override
             public GraqlInsert next() {
                 queriesGenerated++;
-                Variable attr = new Variable().asUserDefined();
+                Variable attr = new Variable().asReturnedVar();
                 Datatype value = valueProvider.next(); // get one attribute value
 
                 Statement attributeValue = var(attr);

--- a/generator/query/RelationGenerator.java
+++ b/generator/query/RelationGenerator.java
@@ -135,7 +135,7 @@ public class RelationGenerator implements QueryGenerator {
                     while (conceptProvider.hasNext() && rolePlayersAssigned < rolePlayersRequired) {
                         ConceptId conceptId = conceptProvider.next();
                         // Add the concept to the query
-                        Variable v = new Variable().asUserDefined();
+                        Variable v = new Variable().asReturnedVar();
                         if (matchVarPattern == null) {
                             matchVarPattern = var(v).id(conceptId.toString());
                         } else {

--- a/profiler/src/BUILD
+++ b/profiler/src/BUILD
@@ -23,6 +23,7 @@ java_library(
         "//common/analysis:insert-query-analyser",
         "//common/configuration:benchmark-configuration",
         "//common/exception:benchmark-exception",
+        "//common/timer:timer",
         "//generator:data-generator",
 
         "@graknlabs_client_java//:client-java",

--- a/profiler/src/GraknBenchmark.java
+++ b/profiler/src/GraknBenchmark.java
@@ -34,6 +34,7 @@ import grakn.benchmark.generator.storage.IgniteConceptStorage;
 import grakn.benchmark.generator.util.IgniteManager;
 import grakn.benchmark.generator.util.SchemaManager;
 import grakn.benchmark.profiler.util.ElasticSearchManager;
+import grakn.benchmark.common.timer.BenchmarkingTimer;
 import grakn.benchmark.profiler.util.TracingGraknClient;
 import grakn.client.GraknClient;
 import grakn.core.concept.type.AttributeType;
@@ -43,14 +44,12 @@ import org.apache.ignite.Ignite;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static graql.lang.Graql.parseList;
@@ -120,11 +119,17 @@ public class GraknBenchmark {
             DataGenerator dataGenerator = initDataGenerator(client, config.getKeyspace()); // use a non tracing client as we don't trace data generation yet
             List<Integer> numConceptsInRun = config.scalesToProfile();
 
+            BenchmarkingTimer timer = new BenchmarkingTimer();
+
             try {
+                timer.startGenerateAndTrack();
                 for (int numConcepts : numConceptsInRun) {
                     LOG.info("Generating graph to scale... " + numConcepts);
-                    dataGenerator.generate(numConcepts);
+                    dataGenerator.generate(numConcepts, timer);
+                    timer.startQueryTimeTracking();
                     threadedProfiler.processStaticQueries(config.numQueryRepetitions(), numConcepts);
+                    timer.endQueryTimeTracking();
+                    timer.printTimings();
                 }
             } catch (Exception e) {
                 throw e;

--- a/profiler/src/QueryProfiler.java
+++ b/profiler/src/QueryProfiler.java
@@ -180,6 +180,6 @@ class QueryProfiler implements Runnable {
             session.close();
         }
         System.out.println("Thread runnable finished running queries");
-        System.out.print("\n\n");
+        System.out.print("\n");
     }
 }

--- a/profiler/src/QueryProfiler.java
+++ b/profiler/src/QueryProfiler.java
@@ -141,7 +141,7 @@ class QueryProfiler implements Runnable {
                                 List<Pattern> match = new ArrayList<>();
                                 List<Variable> vars = new ArrayList<>();
                                 for (String conceptId : insertedConceptIds) {
-                                    Variable var = new Variable().asUserDefined();
+                                    Variable var = new Variable().asReturnedVar();
                                     vars.add(var);
                                     StatementThing id = var(var).id(conceptId);
                                     match.add(id);
@@ -157,7 +157,7 @@ class QueryProfiler implements Runnable {
                             List<Pattern> match = new ArrayList<>();
                             List<Variable> vars = new ArrayList<>();
                             for (String conceptId : insertedConceptIds) {
-                                Variable var = new Variable().asUserDefined();
+                                Variable var = new Variable().asReturnedVar();
                                 vars.add(var);
                                 StatementThing id = var(var).id(conceptId);
                                 match.add(id);

--- a/profiler/src/ThreadedProfiler.java
+++ b/profiler/src/ThreadedProfiler.java
@@ -100,7 +100,7 @@ public class ThreadedProfiler {
         }
 
         long length = System.currentTimeMillis() - start;
-        System.out.println("Time: " + length);
+        System.out.println("Query execution time: " + length);
     }
 
     public void cleanup() {

--- a/report/producer/BUILD
+++ b/report/producer/BUILD
@@ -26,6 +26,7 @@ java_library(
         "//generator:data-generator",
         "//common/configuration:benchmark-configuration",
         "//common/exception:benchmark-exception",
+        "//common/timer:timer",
 
         "@graknlabs_client_java//:client-java",
         "@graknlabs_grakn_core//api:api",

--- a/report/producer/ReportProducer.java
+++ b/report/producer/ReportProducer.java
@@ -108,7 +108,8 @@ public class ReportProducer {
         loadSchema(client, keyspace, config.getGraqlSchema());
 
         // create the data generator
-        DataGenerator dataGenerator = initDataGenerator(client, keyspace);
+        BenchmarkingTimer timer = new BenchmarkingTimer();
+        DataGenerator dataGenerator = initDataGenerator(client, keyspace, timer);
 
         // write the relevant config metadata to the report
         reportData.addMetadata(config.configName(), config.concurrentClients(), config.configDescription(), config.dataGenerator());
@@ -116,13 +117,12 @@ public class ReportProducer {
         // alternate between generating data and profiling a queries
         List<GraqlQuery> queries = toGraqlQueries(config.getQueries());
 
-        BenchmarkingTimer timer = new BenchmarkingTimer();
         try {
             timer.startGenerateAndTrack();
             for (int graphScale : config.scalesToProfile()) {
                 LOG.info("Generating graph to scale... " + graphScale);
                 // NOTE number of concepts actually generated may be just around the desired quantity
-                dataGenerator.generate(graphScale, timer);
+                dataGenerator.generate(graphScale);
 
                 // collect and aggregate results
                 timer.startQueryTimeTracking();
@@ -175,7 +175,7 @@ public class ReportProducer {
     /**
      * Connect a data generator to pre-prepared keyspace
      */
-    private DataGenerator initDataGenerator(GraknClient client, String keyspace) {
+    private DataGenerator initDataGenerator(GraknClient client, String keyspace, BenchmarkingTimer timer) {
         int randomSeed = 0;
         GraknClient.Session session = client.session(keyspace);
 
@@ -188,7 +188,7 @@ public class ReportProducer {
         String dataGenerator = config.dataGenerator();
         DataGeneratorDefinition dataGeneratorDefinition = DefinitionFactory.getDefinition(dataGenerator, new Random(randomSeed), storage);
         QueryProvider queryProvider = new QueryProvider(dataGeneratorDefinition);
-        return new DataGenerator(client, keyspace, storage, dataGenerator, queryProvider);
+        return new DataGenerator(client, keyspace, storage, dataGenerator, queryProvider, timer);
     }
 
     private List<GraqlQuery> toGraqlQueries(List<String> queries) {


### PR DESCRIPTION
When using data generator in conjunction with profiling or recording, we have a couple of heavyweight operations going on: 
1) querying (ie. profilng how long queries take, the actual goal)
2) generating the graphs to profile agains
3) generating the queries that create the graph (this is the bit using Ignite extensively)

It was a nice to have from #176 to track the proportion of time spent on each. This PR implements this with a new small class in `//common/timer` called `BenchmarkTimer`. It simply sums up time spent on:
1) executing the profiler/recorder queries (everything, including deleting inserted instances) -- corresponds to point 1 above
2) executing `insert` queries that grow the graph (corresponds to point 2 above)
3) everything else, which roughly corresponds to time spent on ignite and generating queries (point 3 above)


--- also, bump dependencies on client-java, graql, and build-tools. These are also going to be auto-updated by `grabl`