### PR TITLE
refactors Inspect and TabularView + makes ExecutionCard reusable

### DIFF
--- a/service/dashboard/src/assets/css/_overrides.scss
+++ b/service/dashboard/src/assets/css/_overrides.scss
@@ -9,3 +9,12 @@
     margin: -$margin-default;
   }
 }
+
+.el-card.flexed .el-card__body {
+  align-content: center;
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  vertical-align: baseline;
+}

--- a/service/dashboard/src/util/filters.js
+++ b/service/dashboard/src/util/filters.js
@@ -5,3 +5,8 @@ Vue.filter('parseDate', (ISOdate) => {
   const epoch = Date.parse(ISOdate);
   return new Date(epoch).toLocaleString('en-GB', { hour12: false });
 });
+
+Vue.filter('replaceBlank', (str, replacement) => {
+  if (str === '' || str === null) return replacement;
+  return str;
+});

--- a/service/dashboard/src/views/executions/Executions.vue
+++ b/service/dashboard/src/views/executions/Executions.vue
@@ -55,7 +55,7 @@
     </el-header>
 
     <div class="executions-list">
-      <execution-card v-for="exec in executions" :key="exec.id" :execution="exec"/>
+      <execution-card v-for="exec in executions" :key="exec.id" :execution="exec" :columns="columns"/>
     </div>
   </section>
 </template>
@@ -71,8 +71,11 @@ export default {
   data() {
     return {
       loading: true,
+
       // popoverVisible: false,
+
       executions: [],
+
       columns: [
         {
           text: "Commit",
@@ -103,29 +106,6 @@ export default {
   },
 
   created() {
-    this.columns = [
-      {
-        text: "Commit",
-        value: "commit"
-      },
-      {
-        text: "Status",
-        value: "status"
-      },
-      {
-        text: "Initialised At",
-        value: "executionInitialisedAt"
-      },
-      {
-        text: "Started At",
-        value: "executionStartedAt"
-      },
-      {
-        text: "Completed At",
-        value: "executionCompletedAt"
-      }
-    ];
-
     BenchmarkClient.getExecutions(
       "{ executions { id " +
         this.columns.map(item => item.value).join(" ") +

--- a/service/dashboard/src/views/inspect/Inspect.vue
+++ b/service/dashboard/src/views/inspect/Inspect.vue
@@ -1,129 +1,110 @@
 <template>
-  <el-container>
-    <el-main>
-      <el-card
-        :body-style="{ padding: '15px', border: '1px solid #e2e2e2' }"
-        shadow="never"
-      >
-        <el-row style="margin-bottom: 5px; font-weight: bold; text-align:center;">
-          <el-col :span="3">
-            STATUS
-          </el-col>
-          <el-col :span="4">
-            REPOSITORY
-          </el-col>
-          <el-col :span="7">
-            COMMIT
-          </el-col>
-          <el-col :span="2">
-            PR
-          </el-col>
-          <el-col :span="4">
-            STARTED AT
-          </el-col>
-          <el-col :span="4">
-            COMPLETED AT
-          </el-col>
-        </el-row>
-        <el-row
-          type="flex"
-          align="middle"
-          style="text-align:center;"
-        >
-          <el-col :span="3">
-            <el-tag
-              size="mini"
-              :type="execution.status == 'COMPLETED' ? 'success' : 'danger'"
-            >
-              {{ execution.status }}
-            </el-tag>
-          </el-col>
-          <el-col :span="4">
-            <a :href="execution.repoUrl">{{ execution.repoUrl | substringRepo }}</a>
-          </el-col>
-          <el-col :span="7">
-            <a :href="execution.repoUrl + '/commit/' + execution.commit">{{ execution.commit }}</a>
-          </el-col>
-          <el-col :span="2">
-            <a :href="execution.prUrl">#{{ execution.prNumber }}</a>
-          </el-col>
-          <el-col :span="4">
-            {{ execution.executionStartedAt }}
-          </el-col>
-          <el-col :span="4">
-            {{ execution.executionCompletedAt }}
-          </el-col>
-        </el-row>
-      </el-card>
-      <tabular-view
-        :graphs="graphs"
-        :execution-spans="executionSpans"
-        :current-graph="currentGraph"
-        :current-scale="currentScale"
-        :current-query="currentQuery"
-      />
-    </el-main>
-  </el-container>
+  <section>
+    <div v-if="execution">
+      <execution-card class="execution-card" :execution="execution" :columns="executionColumns"/>
+    </div>
+
+    <tabular-view
+      :graph-names="graphNames"
+      :spans="spans"
+      :pre-selected-graph-name="preSelectedGraphName"
+      :pre-selected-query="preSelectedQuery"
+      :pre-selected-scale="preSelectedScale"
+    />
+  </section>
 </template>
 
 <script>
-import BenchmarkClient from '@/util/BenchmarkClient';
-import TabularView from './TabularView/TabularView.vue';
+import BenchmarkClient from "@/util/BenchmarkClient";
+import ExecutionCard from "@/views/executions/ExecutionCard.vue";
+import TabularView from "./TabularView/TabularView.vue";
 
 export default {
-  components: { TabularView },
-
-  filters: {
-    substringRepo(repoUrl) {
-      if (!repoUrl) return '';
-      return repoUrl.substring(19);
-    },
-  },
+  components: { TabularView, ExecutionCard },
 
   data() {
     return {
       executionId: this.$route.params.executionId,
-      currentGraph: this.$route.query.graph,
-      currentScale: parseInt(this.$route.query.scale, 0),
-      currentQuery: this.$route.query.query,
-      execution: {},
-      executionSpans: [],
-      graphs: [],
+
+      execution: null,
+
+      spans: [],
+
+      graphNames: [],
+
+      preSelectedGraphName: this.$route.query.graph,
+
+      preSelectedQuery: this.$route.query.query,
+
+      preSelectedScale: parseInt(this.$route.query.scale, 0),
+
+      executionColumns: [
+        {
+          text: "Status",
+          value: "status"
+        },
+        {
+          text: "Repository",
+          value: "repoUrl"
+        },
+        {
+          text: "Commit",
+          value: "commit"
+        },
+        {
+          text: "PR",
+          value: "prUrl"
+        },
+        {
+          text: "Started At",
+          value: "executionStartedAt"
+        },
+        {
+          text: "Completed At",
+          value: "executionCompletedAt"
+        }
+      ]
     };
   },
 
   created() {
-    this.fetchExecutionDetails();
-    this.fetchExecutionSpans();
+    this.fetchExecution();
+    this.fetchSpans();
   },
 
   methods: {
-    fetchExecutionDetails() {
+    fetchExecution() {
       BenchmarkClient.getExecutions(
-        `{ executionById(id: "${
+        `{ executionById (id: "${
           this.executionId
-        }"){ prMergedAt prNumber prUrl commit status executionStartedAt executionCompletedAt repoUrl} }`,
-      ).then((resp) => {
+        }"){ id prNumber
+          ${this.executionColumns.map(column => column.value).join(" ")}
+        } }`
+      ).then(resp => {
         this.execution = resp.data.executionById;
       });
     },
-    fetchExecutionSpans() {
+
+    fetchSpans() {
       BenchmarkClient.getSpans(
         `{ executionSpans( executionName: "${
           this.executionId
-        }"){ id name duration tags { graphType executionName graphScale }} }`,
-      ).then((resp) => {
-        this.executionSpans = resp.data.executionSpans;
-        // Extract Graph types from execution spans
-        this.graphs = Array.from(
-          new Set(this.executionSpans.map(span => span.tags.graphType)),
+        }"){ id name duration tags { graphType executionName graphScale }} }`
+      ).then(resp => {
+        this.spans = resp.data.executionSpans;
+
+        this.graphNames = Array.from(
+          new Set(this.spans.map(span => span.tags.graphType))
         );
       });
-    },
-  },
+    }
+  }
 };
 </script>
-<style scoped>
+
+<style scoped lang="scss">
+@import "./src/assets/css/variables.scss";
+
 .el-container {
   background-color: #f4f3ef;
 }

--- a/service/dashboard/src/views/inspect/TabularView/TabularView.vue
+++ b/service/dashboard/src/views/inspect/TabularView/TabularView.vue
@@ -1,65 +1,84 @@
 <template>
   <el-tabs
-    v-model="activeGraph"
+    :value="activeGraph"
     type="border-card"
     class="wrapper"
   >
     <el-tab-pane
-      v-for="graph in graphs"
-      :key="graph"
-      :label="graph"
+      v-for="graphName in graphNames"
+      :key="graphName"
+      :label="graphName"
+      :name="graphName"
     >
       <graph-tab
-        :graph="graph"
-        :execution-spans="filterSpans(graph)"
-        :overview-scale="getOverviewScale(graph)"
-        :overview-query="getOverviewQuery(graph)"
+        :graph="graphName"
+        :execution-spans="getFilterSpans(graphName)"
+        :overview-query="getPreSelectedQuery(graphName)"
+        :overview-scale="getPreSelectedScale(graphName)"
       />
     </el-tab-pane>
   </el-tabs>
 </template>
+
 <script>
 import GraphTab from './GraphTab.vue';
 
 export default {
   name: 'TabularView',
+
   components: { GraphTab },
+
   props: {
-    graphs: Array,
-    executionSpans: Array,
-    currentGraph: String,
-    currentQuery: String,
-    currentScale: Number,
-  },
-  data() {
-    return {
-      activeGraph: '0',
-    };
-  },
-  watch: {
-    graphs(values) {
-      // Once the graphs are available check if we need to select Graph tab based on the
-      // currentGraph parameter that comes from the Ovierview page.
-      if (this.currentGraph) {
-        this.activeGraph = values.indexOf(this.currentGraph).toString();
-      }
+    graphNames: {
+      type: Array,
+      required: true
     },
+
+    spans: {
+      type: Array,
+      required: true
+    },
+
+    preSelectedGraphName: {
+      type: String,
+      required: false,
+    },
+
+    preSelectedQuery: {
+      type: String,
+      required: false,
+    },
+
+    preSelectedScale: {
+      type: Number,
+      required: false
+    }
   },
+
+  computed: {
+    activeGraph() {
+      return this.preSelectedGraphName || this.graphNames[0];
+    }
+  },
+
   methods: {
-    filterSpans(name) {
-      return this.executionSpans.filter(span => span.tags.graphType === name);
+    getFilterSpans(graphName) {
+      return this.spans.filter(span => span.tags.graphType === graphName);
     },
-    getOverviewScale(graphType) {
-      if (this.currentGraph === graphType) { return this.currentScale; }
+
+    getPreSelectedScale(graphName) {
+      if (this.preSelectedGraphName === graphName) { return this.preSelectedScale; }
       return null;
     },
-    getOverviewQuery(graphType) {
-      if (this.currentGraph === graphType) { return this.currentQuery; }
+
+    getPreSelectedQuery(graphName) {
+      if (this.preSelectedGraphName === graphName) { return this.preSelectedQuery; }
       return null;
     },
   },
 };
 </script>
+
 <style scoped>
 .wrapper {
   margin-top: 20px;


### PR DESCRIPTION
### ExecutionCard 
- uses`flex` instead of `row` and `col` with `span`. this allows us to display a dynamic number of columns on the card without having to readjust their positioning.
- handles conditional rendering of columns. only if the column is included within the `columns`  prop, it renders that particular column. this allows reusability of the `ExecutionCard` and separation of logic from representation.
- takes the tooltip text from the `columns` prop.

### Inspect
- reuses ExecutionCard

### ExecutionCard, Inspect and TabularView
- renames variables and methods for better understandability

