### PR TITLE
Refactors GraphTab

### DIFF
--- a/service/dashboard/src/views/inspect/TabularView/GraphTab.vue
+++ b/service/dashboard/src/views/inspect/TabularView/GraphTab.vue
@@ -8,7 +8,7 @@
         title="Scale"
         :items="scales.map(scale => ({ text: scale, value: scale }))"
         :defaultItem="{ text: selectedScale, value: selectedScale }"
-        @item-selected="onScaleSelection"
+        @item-selected="this.selectedScale = scale;"
       />
     </el-row>
     <queries-table
@@ -62,12 +62,6 @@ export default {
     ].sort((a, b) => a - b);
     this.selectedScale = this.preSelectedScale || this.scales[0];
   },
-
-  methods: {
-    onScaleSelection(scale) {
-      this.selectedScale = scale;
-    }
-  }
 };
 
 </script>

--- a/service/dashboard/src/views/inspect/TabularView/GraphTab.vue
+++ b/service/dashboard/src/views/inspect/TabularView/GraphTab.vue
@@ -5,46 +5,69 @@
       justify="end"
     >
       <scale-selector
-        :scales="scales"
-        :current-scale="currentScale"
-        @selected-scale="(scale)=>{currentScale=scale}"
+        title="Scale"
+        :items="scales.map(scale => ({ text: scale, value: scale }))"
+        :defaultItem="{ text: selectedScale, value: selectedScale }"
+        @item-selected="onScaleSelection"
       />
     </el-row>
     <queries-table
       v-for="scale in scales"
-      v-show="scale==currentScale"
+      v-show="scale==selectedScale"
       :key="scale"
+      :execution-spans="spans"
+      :overview-query="preSelectedQuery"
       :current-scale="scale"
-      :execution-spans="executionSpans"
-      :overview-query="overviewQuery"
     />
   </div>
 </template>
 <script>
 
 import QueriesTable from './QueriesTable.vue';
-import ScaleSelector from '@/components/ScaleSelector.vue';
+import ScaleSelector from '@/components/Selector.vue';
+
 
 export default {
   name: 'GraphTab',
+
   components: { ScaleSelector, QueriesTable },
+
   props: {
-    graph: String,
-    executionSpans: Array,
-    overviewScale: Number,
-    overviewQuery: String,
+    spans: {
+      type: Array,
+      required: true
+    },
+
+    preSelectedQuery: {
+      type: String,
+      required: false
+    },
+
+    preSelectedScale: {
+      type: Number,
+      required: false
+    },
   },
+
   data() {
     return {
       scales: [],
-      currentScale: null,
+      selectedScale: null,
     };
   },
+
   created() {
-    this.scales = [...new Set(this.executionSpans.map(span => span.tags.graphScale))];
-    this.scales.sort((a, b) => a - b);
-    this.currentScale = (this.overviewScale) ? this.overviewScale : this.scales[0];
+    this.scales = [
+      ...new Set(this.spans.map(span => span.tags.graphScale)),
+    ].sort((a, b) => a - b);
+    this.selectedScale = this.preSelectedScale || this.scales[0];
   },
+
+  methods: {
+    onScaleSelection(scale) {
+      this.selectedScale = scale;
+    }
+  }
 };
 
 </script>

--- a/service/dashboard/src/views/inspect/TabularView/TabularView.vue
+++ b/service/dashboard/src/views/inspect/TabularView/TabularView.vue
@@ -1,65 +1,83 @@
 <template>
   <el-tabs
-    v-model="activeGraph"
+    :value="activeGraph"
     type="border-card"
     class="wrapper"
   >
     <el-tab-pane
-      v-for="graph in graphs"
-      :key="graph"
-      :label="graph"
+      v-for="graphName in graphNames"
+      :key="graphName"
+      :label="graphName"
+      :name="graphName"
     >
       <graph-tab
-        :graph="graph"
-        :execution-spans="filterSpans(graph)"
-        :overview-scale="getOverviewScale(graph)"
-        :overview-query="getOverviewQuery(graph)"
+        :spans="getFilterSpans(graphName)"
+        :pre-selected-query="getPreSelectedQuery(graphName)"
+        :pre-selected-scale="getPreSelectedScale(graphName)"
       />
     </el-tab-pane>
   </el-tabs>
 </template>
+
 <script>
 import GraphTab from './GraphTab.vue';
 
 export default {
   name: 'TabularView',
+
   components: { GraphTab },
+
   props: {
-    graphs: Array,
-    executionSpans: Array,
-    currentGraph: String,
-    currentQuery: String,
-    currentScale: Number,
-  },
-  data() {
-    return {
-      activeGraph: '0',
-    };
-  },
-  watch: {
-    graphs(values) {
-      // Once the graphs are available check if we need to select Graph tab based on the
-      // currentGraph parameter that comes from the Ovierview page.
-      if (this.currentGraph) {
-        this.activeGraph = values.indexOf(this.currentGraph).toString();
-      }
+    graphNames: {
+      type: Array,
+      required: true
     },
+
+    spans: {
+      type: Array,
+      required: true
+    },
+
+    preSelectedGraphName: {
+      type: String,
+      required: false,
+    },
+
+    preSelectedQuery: {
+      type: String,
+      required: false,
+    },
+
+    preSelectedScale: {
+      type: Number,
+      required: false
+    }
   },
+
+  computed: {
+    activeGraph() {
+      return this.preSelectedGraphName || this.graphNames[0];
+    }
+  },
+
   methods: {
-    filterSpans(name) {
-      return this.executionSpans.filter(span => span.tags.graphType === name);
+    getFilterSpans(graphName) {
+      return this.spans.filter(span => span.tags.graphType === graphName);
     },
-    getOverviewScale(graphType) {
-      if (this.currentGraph === graphType) { return this.currentScale; }
+
+    getPreSelectedScale(graphName) {
+      if (this.preSelectedGraphName === graphName) { return this.preSelectedScale; }
       return null;
     },
-    getOverviewQuery(graphType) {
-      if (this.currentGraph === graphType) { return this.currentQuery; }
+
+    getPreSelectedQuery(graphName) {
+      if (this.preSelectedGraphName === graphName) { return this.preSelectedQuery; }
       return null;
     },
   },
 };
 </script>
+
 <style scoped>
 .wrapper {
   margin-top: 20px;

--- a/service/dashboard/src/views/overview/ChartCommits.vue
+++ b/service/dashboard/src/views/overview/ChartCommits.vue
@@ -11,8 +11,8 @@
       <div class="actions">
         <scale-selector
           title="Scale"
-          :items="scales"
-          :defaultItem="scales[0]"
+          :items="scales.map(scale => ({ text: scale, value: scale }))"
+          :defaultItem="{ text: scales[0], value: scales[0] }"
           @item-selected="onScaleSelection"
         />
       </div>
@@ -86,9 +86,9 @@ export default {
   async created() {
     this.scales = [
       ...new Set(this.executionSpans.map(span => span.tags.graphScale)),
-    ].sort((a, b) => a - b).map(scale => ({ text: scale, value: scale }));
+    ].sort((a, b) => a - b);
 
-    this.selectedScale = this.scales[0].value;
+    this.selectedScale = this.scales[0];
 
     this.querySpans = await fetchQuerySpans(this.executionSpans);
     this.queries = uniqueQueriesSortedArray(this.querySpans);


### PR DESCRIPTION
- GraphTab: uses the recently created `Selector.vue` in place of `ScaleSelector.vue`
- ChartCommits: modifies how props of `Selector` are assigned to be consistent across all usages of `Selector`