### PR TITLE
Makes charts zoomable

### DIFF
--- a/service/dashboard/package.json
+++ b/service/dashboard/package.json
@@ -13,7 +13,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.8.1",
     "@fortawesome/vue-fontawesome": "^0.1.6",
     "copy-to-clipboard": "^3.1.0",
-    "echarts": "^4.2.0-rc.2",
+    "echarts": "4.1.0",
     "element-ui": "^2.4.11",
     "ordinal": "^1.0.3",
     "vue": "^2.5.21",

--- a/service/dashboard/src/views/overview/ChartCommits.vue
+++ b/service/dashboard/src/views/overview/ChartCommits.vue
@@ -30,6 +30,7 @@ import 'echarts/lib/chart/line';
 import 'echarts/lib/component/tooltip';
 import 'echarts/lib/component/legend';
 import 'echarts/lib/component/legendScroll';
+import 'echarts/lib/component/dataZoom';
 import ScaleSelector from '@/components/Selector.vue';
 import EDF from '@/util/ExecutionDataFormatters';
 

--- a/service/dashboard/yarn.lock
+++ b/service/dashboard/yarn.lock
@@ -2919,12 +2919,12 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-echarts@^4.2.0-rc.2:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/echarts/-/echarts-4.2.1.tgz#9a8ea3b03354f86f824d97625c334cf16965ef03"
-  integrity sha512-pw4xScRPsLegD/cqEcoXRKeA2SD4+s+Kyo0Na166NamOWhzNl2yI5RZ2rE97tBlAopNmhyMeBVpAeD5qb+ee1A==
+echarts@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/echarts/-/echarts-4.1.0.tgz#d588c95f73c1a9928b9c73d5b769751c3185bcdc"
+  integrity sha512-gP1e1fNnAj9KJpTDLXV21brklbfJlqeINmpQDJCDta9TX3cPoqyQOiDVcEPzbOVHqgBRgTOwNxC5iGwJ89014A==
   dependencies:
-    zrender "4.0.7"
+    zrender "4.0.4"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -8634,7 +8634,7 @@ yorkie@^2.0.0:
     normalize-path "^1.0.0"
     strip-indent "^2.0.0"
 
-zrender@4.0.7:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/zrender/-/zrender-4.0.7.tgz#15ae960822f5efed410995d37e5107fe3de10e6d"
-  integrity sha512-TNloHe0ums6zxbHfnaCryM61J4IWDajZwNq6dHk9vfWhhysO/OeFvvR0drBs/nbXha2YxSzfQj2FiCd6RVBe+Q==
+zrender@4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/zrender/-/zrender-4.0.4.tgz#910e60d888f00c9599073f23758dd23345fe48fd"
+  integrity sha512-03Vd/BDl/cPXp8E61f5+Xbgr/a4vDyFA+uUtUc1s+5KgcPbyY2m+78R/9LQwkR6QwFYHG8qk25Q8ESGs/qpkZw==


### PR DESCRIPTION
closes #199 
- downgrades dependency: echarts from 1.4.2 to 1.4.1. this is to avoid the echarts bug with scroll/zoom conflicting behaviour
- imports the echart's dataZoom component