### PR TITLE
Re-enable complex queries

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
-build --workspace_status_command --java_toolchain @graknlabs_build_tools//bazel:java-toolchain
+build --java_toolchain @graknlabs_build_tools//bazel:java-toolchain
 build:rbe --project_id=grakn-dev
 build:rbe --remote_instance_name=projects/grakn-dev/instances/default_instance
 build:rbe --remote_cache=remotebuildexecution.googleapis.com

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
-build --workspace_status_command bin/workspace_status.sh --java_toolchain @graknlabs_build_tools//bazel:java-toolchain
+build --workspace_status_command --java_toolchain @graknlabs_build_tools//bazel:java-toolchain
 build:rbe --project_id=grakn-dev
 build:rbe --remote_instance_name=projects/grakn-dev/instances/default_instance
 build:rbe --remote_cache=remotebuildexecution.googleapis.com

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,18 +1,19 @@
+build --workspace_status_command bin/workspace_status.sh --java_toolchain @graknlabs_build_tools//bazel:java-toolchain
 build:rbe --project_id=grakn-dev
 build:rbe --remote_instance_name=projects/grakn-dev/instances/default_instance
 build:rbe --remote_cache=remotebuildexecution.googleapis.com
 build:rbe --remote_executor=remotebuildexecution.googleapis.com
 build:rbe --bes_backend="buildeventservice.googleapis.com"
 build:rbe --bes_results_url="https://source.cloud.google.com/results/invocations/"
-build:rbe --host_platform=//:rbe-platform
-build:rbe --platforms=//:rbe-platform
-build:rbe --extra_execution_platforms=//:rbe-platform
-build:rbe --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:jdk8
-build:rbe --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:jdk8
+build:rbe --host_platform=@graknlabs_build_tools//:rbe-ubuntu1604-network-standard
+build:rbe --platforms=@graknlabs_build_tools//:rbe-ubuntu1604-network-standard
+build:rbe --extra_execution_platforms=@graknlabs_build_tools//:rbe-ubuntu1604-network-standard
+build:rbe --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/9.0.0/bazel_0.25.2/java:jdk
+build:rbe --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/9.0.0/bazel_0.25.2/java:jdk
 build:rbe --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
 build:rbe --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:rbe --extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/1.1/bazel_0.20.0/cpp:cc-toolchain-clang-x86_64-default
-build:rbe --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/1.1/bazel_0.20.0/default:toolchain
+build:rbe --extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/9.0.0/bazel_0.25.2/config:cc-toolchain
+build:rbe --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/9.0.0/bazel_0.25.2/cc:toolchain
 build:rbe --jobs=50
 build:rbe --remote_timeout=3600
 build:rbe --bes_timeout=60s
@@ -25,11 +26,3 @@ build:rbe --genrule_strategy=remote
 build:rbe --define=EXECUTOR=remote
 build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:rbe --experimental_strict_action_env=true
-
-# The following configuration forces Bazel to execute rules which depends on pkg_rpm() locally instead of in RBE.
-# The assemble_rpm() macro uses pkg_rpm() which uses the 'rpmbuild' binary under the hood.
-# It won't be available in some distributions and therefore can't be ran in RBE.
-# When executed, the pkg_rpm() rule will produce the "MakeRpm" Bazel actions
-# (you can look at what actions are produced when a target is executed by adding -s: bazel build -s //target:name).
-# Here we configure Bazel to execute "MakeRpm" actions locally:
-build:rbe --strategy_regexp=MakeRpm=local

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+Please replace every line in curly brackets ( { like this } ) with an appropriate description, and remove this line.
+
+## What is the goal of this PR?
+
+{ In the form of a paragraph (only use bullet points if strictly necessary), please describe the goal of this PR, why they are valuable to achieve, and reference the related GitHub issues. This section will be automatically compiled into the release notes, so please:
+  - describe the impact of the change in this PR to the _user_ of this repository (e.g. end user, contributor, developer).
+  - describe the new product behaviour in _present tense_, and the old behaviour and how it's been changed in _past tense_.
+  - Use the _Royal We_: _"We"_ made changes, not _"I"_ made changes. }
+
+## What are the changes implemented in this PR?
+
+{ Please explain what you implemented, why your changes are the best way to achieve the goal(s) above, and reference the GitHub issues to be automatically closed, such like 'closes #number'. }

--- a/common/configuration/scenario/complex/config_read.yml
+++ b/common/configuration/scenario/complex/config_read.yml
@@ -5,7 +5,7 @@ schema: "schema.gql"
 scales:
   - 200
   - 400
-#  - 600
+  - 600
 
 repeatsPerQuery: 2
 

--- a/common/configuration/scenario/complex/queries_complex_read.yml
+++ b/common/configuration/scenario/complex/queries_complex_read.yml
@@ -11,31 +11,43 @@ queries:
       $z isa circle;
       get; limit 5;"
 
-# TODO re-enable when statistics are available to make these queries complete
+  # branching that has attributes at the ends, which means the QP needs to operate depth first for a good plan
+  - "match
+      $b1 isa blob;
+      $b2 isa blob;
+      ($b1, $b2) isa ownership;
+      ($b2, $s1) isa ownership;
+      $s1 has shape-value 3;
+      $c isa circle;
+      ($b1, $c) isa interaction;
+      ($c, $c2) isa sizing;
+      $c2 has circle-value 2; get;"
+
+
   # branching from one entity, width 3, depth 1
-#  - "match
-#      $b1 isa blob;
-#      $b2 isa blob;
-#      ($b1, $b2) isa ownership;
-#      $c isa circle;
-#      ($b1, $c) isa interaction;
-#      $s isa square;
-#      ($b1, $s) isa interaction;
-#      get; limit 5;"
+  - "match
+      $b1 isa blob;
+      $b2 isa blob;
+      ($b1, $b2) isa ownership;
+      $c isa circle;
+      ($b1, $c) isa interaction;
+      $s isa square;
+      ($b1, $s) isa interaction;
+      get; limit 5;"
 #
 #  # branching from one entity, width 3, depth 3
 #  # -
 #
 #  # star, 6 role players, half with attribute values
-#  - "match
-#      ($b1, $b2, $c1, $c2, $s1, $s2) isa interaction;
-#      $b1 isa blob, has blob-value 1;
-#      $b2 isa blob;
-#      $c1 isa circle, has circle-value 2;
-#      $c2 isa circle;
-#      $s1 isa square, has shape-value 3;
-#      $s2 isa square;
-#      get;limit 5;"
+  - "match
+      ($b1, $b2, $c1, $c2, $s1, $s2) isa interaction;
+      $b1 isa blob, has blob-value 1;
+      $b2 isa blob;
+      $c1 isa circle, has circle-value 2;
+      $c2 isa circle;
+      $s1 isa square, has shape-value 3;
+      $s2 isa square;
+      get;limit 5;"
 #
 #  # circle (ie. pentagon)
 #  - "match
@@ -55,20 +67,20 @@ queries:
 #  # It may be interesting to keep the ternary relations as unspecific types to see if we
 #  # can prune search space using histograms of connectivity (eg. the only relations with more than 2
 #  # role players are actually interactions!). Meanwhile many relations have two RPs so we don't gain any information
-#  - "match
-#      $b1 isa blob;
-#      $b2 isa blob;
-#      $c isa circle;
-#      $s isa square;
-#      ($b1, $b2) isa sizing;
-#      ($b2, $c) isa ownership;
-#      ($c, $s) isa ownership;
-#      ($s, $b1) isa interaction;
-#      ($b1, $c) isa relation;
-#      (bigger: $b2, smaller: $s) isa sizing;
-#      ($b1, $b2, $c) isa relation;
-#      ($b1, $b2, $s) isa relation;
-#      ($b2, $c, $s) isa relation;
-#      ($b1, $c, $s) isa relation;
-#      ($b1, $b2, $c, $s) isa interaction;
-#      get;limit 5;"
+  - "match
+      $b1 isa blob;
+      $b2 isa blob;
+      $c isa circle;
+      $s isa square;
+      ($b1, $b2) isa sizing;
+      ($b2, $c) isa ownership;
+      ($c, $s) isa ownership;
+      ($s, $b1) isa interaction;
+      ($b1, $c) isa relation;
+      (bigger: $b2, smaller: $s) isa sizing;
+      ($b1, $b2, $c) isa relation;
+      ($b1, $b2, $s) isa relation;
+      ($b2, $c, $s) isa relation;
+      ($b1, $c, $s) isa relation;
+      ($b1, $b2, $c, $s) isa interaction;
+      get;limit 5;"

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,7 +22,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "a8c117758461368bff9841f9659bff11afbf02a1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "07b926e538dfcf25dc820c4d95db0995a0e67ff1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_grakn_core():

--- a/profiler/src/BUILD
+++ b/profiler/src/BUILD
@@ -29,7 +29,6 @@ java_library(
         "@graknlabs_client_java//:client-java",
         "@graknlabs_graql//java:graql",
         "@graknlabs_grakn_core//api:api",
-        "@graknlabs_grakn_core//common:common",
         "@graknlabs_grakn_core//concept:concept",
 
         # together these can be used to create clients with tracing enabled

--- a/profiler/src/GraknBenchmark.java
+++ b/profiler/src/GraknBenchmark.java
@@ -122,11 +122,10 @@ public class GraknBenchmark {
             DataGenerator dataGenerator = initDataGenerator(client, config.getKeyspace(), timer); // use a non tracing client as we don't trace data generation yet
             List<Integer> numConceptsInRun = config.scalesToProfile();
 
-
             try {
                 timer.startGenerateAndTrack();
                 for (int numConcepts : numConceptsInRun) {
-                    LOG.info("Generating graph to scale... " + numConcepts);
+                    LOG.info("\n Generating graph to scale... " + numConcepts);
                     dataGenerator.generate(numConcepts);
                     timer.startQueryTimeTracking();
                     threadedProfiler.processQueries(config.numQueryRepetitions(), numConcepts);

--- a/profiler/src/QueryProfiler.java
+++ b/profiler/src/QueryProfiler.java
@@ -184,6 +184,5 @@ class QueryProfiler implements Runnable {
             session.close();
         }
         System.out.println("Thread runnable finished running queries");
-        System.out.print("\n");
     }
 }

--- a/profiler/src/ThreadedProfiler.java
+++ b/profiler/src/ThreadedProfiler.java
@@ -103,6 +103,7 @@ public class ThreadedProfiler {
 
     public void cleanup() {
         executorService.shutdown();
+        client.close();
     }
 }
 

--- a/profiler/src/util/TracingGraknClient.java
+++ b/profiler/src/util/TracingGraknClient.java
@@ -21,7 +21,6 @@ package grakn.benchmark.profiler.util;
 
 import grakn.benchmark.lib.instrumentation.ClientInterceptor;
 import grakn.client.GraknClient;
-import grakn.core.common.http.SimpleURI;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 
@@ -29,10 +28,9 @@ public class TracingGraknClient {
 
     public static GraknClient get(String uri) {
         GraknClient client = new GraknClient(uri);
-        SimpleURI parsedURI = new SimpleURI(uri);
 
         ManagedChannel channel = ManagedChannelBuilder
-                .forAddress(parsedURI.getHost(), parsedURI.getPort())
+                .forTarget(uri)
                 .intercept(new ClientInterceptor("client-java-instrumentation"))
                 .usePlaintext().build();
 


### PR DESCRIPTION
We used to have the more complex read queries from `complex` scenario enabled, but removed these because bad query plans meant it wasn't usable. Recent refactors have resulted in better plans (partially by chance) but more improvements can be made which should be tracked.

* reenables several complex read queries 
* fixes the printouts' newline placement.
* removes `SimpleURI` as a dependency, which should fix the breaking benchmark executors.
* Fix BazelRC and update build tools deps