### PR TITLE
Add extra query with insertions to reasoning benchmark

### DIFF
--- a/common/configuration/scenario/reasoning/queries_read.yml
+++ b/common/configuration/scenario/reasoning/queries_read.yml
@@ -3,6 +3,9 @@ queries:
   # transitive closure
   - "match (Q-from: $x, Q-to: $y) isa Q; get; limit 3025;"
 
+  # transitive closure with relation insertion
+  - "match $r (Q-from: $x, Q-to: $y) isa Q; get; limit 3025;"
+
   # exhaustive iterative transitive closure
   - "match (Q-from: $x, Q-to: $y) isa Q; get;"
 


### PR DESCRIPTION
Add an extra query to the reasoning benchmark:
- transitive closure with insertion of relations