### PR TITLE
Includes histogram and other stats in QueryCard 

### DIFF
--- a/service/dashboard/src/util/ExecutionDataFormatters.js
+++ b/service/dashboard/src/util/ExecutionDataFormatters.js
@@ -20,20 +20,16 @@ function flattenQuerySpans(querySpanGroups) {
   }));
 }
 
-function flattenStepSpans(stepSpans, querySpans) {
-  const flattenedSpans = stepSpans.map((stepSpan) => {
-    const { rep } = querySpans.filter(querySpan => querySpan.id === stepSpan.parentId)[0];
-    return {
-      id: stepSpan.id,
-      parentId: stepSpan.parentId,
-      name: stepSpan.name,
-      duration: stepSpan.duration,
-      order: stepSpan.tags ? stepSpan.tags.childNumber : null,
-      timestamp: stepSpan.timestamp,
-      rep,
-    };
-  });
-  return flattenedSpans;
+function flattenStepSpans(stepSpans) {
+  return stepSpans.map(stepSpan => ({
+    id: stepSpan.id,
+    parentId: stepSpan.parentId,
+    name: stepSpan.name,
+    duration: stepSpan.duration,
+    order: stepSpan.tags ? stepSpan.tags.childNumber : null,
+    timestamp: stepSpan.timestamp,
+    // rep,
+  }));
 }
 
 function attachRepsToChildSpans(childSpans, parentSpans) {

--- a/service/dashboard/src/views/inspect/Inspect.vue
+++ b/service/dashboard/src/views/inspect/Inspect.vue
@@ -97,7 +97,6 @@ export default {
         }"){ id name duration tags { graphType executionName graphScale description }} }`,
       );
       const graphs = graphsResp.data.executionSpans;
-      console.log(graphs);
       this.graphs = flattenGraphs(graphs);
 
       const queriesResponse = await Promise.all(

--- a/service/dashboard/src/views/inspect/TabularView/GraphTab.vue
+++ b/service/dashboard/src/views/inspect/TabularView/GraphTab.vue
@@ -4,7 +4,7 @@
       type="flex"
       justify="start"
       align="middle"
-      class="queries-action-bar"
+      class="queriesActionBar"
     >
       <p class="graphDescription">
         {{ graphDescription }}
@@ -96,12 +96,9 @@ export default {
 <style scoped lang="scss">
 @import "./src/assets/css/variables.scss";
 
-.queries-action-bar {
+.queriesActionBar {
   color: darken($color-text-gray, 20%);
   padding-bottom: $padding-default;
-
-  .action-item, .graphDescription {
-    padding-right: $padding-default;
-  }
+  justify-content: space-between;
 }
 </style>

--- a/service/dashboard/src/views/inspect/TabularView/GroupLine.vue
+++ b/service/dashboard/src/views/inspect/TabularView/GroupLine.vue
@@ -9,32 +9,11 @@
         {{ groupName | truncate(100) }}
       </span>
 
-      <el-tooltip
-        class="item"
-        effect="dark"
-        :content="minTooltipContent()"
-        placement="top"
-      >
-        <span>{{ minSpan.duration | fixedMs }}/<a :href="'#' + groupName + indexOfMinSpan">{{ indexOfMinSpan | ordinalise }}</a></span>
-      </el-tooltip>
+      <span>{{ minSpan.duration | fixedMs }}/<a :href="'#' + groupName + indexOfMinSpan">{{ indexOfMinSpan | ordinalise }}</a></span>
 
-      <el-tooltip
-        class="item"
-        effect="dark"
-        :content="medianTooltipContent()"
-        placement="top"
-      >
-        <span>{{ median | fixedMs }}/{{ reps }}</span>
-      </el-tooltip>
+      <span>{{ median | fixedMs }}/{{ reps }}</span>
 
-      <el-tooltip
-        class="item"
-        effect="dark"
-        :content="maxTooltipContent()"
-        placement="top"
-      >
-        <span>{{ maxSpan.duration | fixedMs }}/<a :href="'#' + groupName + indexOfMaxSpan">{{ indexOfMaxSpan | ordinalise }}</a></span>
-      </el-tooltip>
+      <span>{{ maxSpan.duration | fixedMs }}/<a :href="'#' + groupName + indexOfMaxSpan">{{ indexOfMaxSpan | ordinalise }}</a></span>
     </div>
     <div v-if="expaned">
       <step-line
@@ -156,27 +135,6 @@ export default {
 
     isSpanSlowest(order) {
       return this.indexOfMaxSpan === order - this.firstMemberOrder + 1;
-    },
-
-    minTooltipContent() {
-      const { ordinalise } = this.$options.filters;
-      return `The ${ordinalise(
-        this.minSpan.rep + 1,
-      )} step in this group was the FASTEST.`;
-    },
-
-    maxTooltipContent() {
-      const { ordinalise } = this.$options.filters;
-      return `The ${ordinalise(
-        this.maxSpan.rep + 1,
-      )} step in this group was the SLOWEST.`;
-    },
-
-    medianTooltipContent() {
-      const { fixedMs } = this.$options.filters;
-      return `Among all ${Object.keys(this.members).length} members of this group, the median was ${fixedMs(
-        this.median,
-      )}.`;
     },
   },
 };

--- a/service/dashboard/src/views/inspect/TabularView/StepLine.vue
+++ b/service/dashboard/src/views/inspect/TabularView/StepLine.vue
@@ -10,36 +10,15 @@
         {{ step | truncate(100) }}
       </span>
 
-      <el-tooltip
-        class="item"
-        effect="dark"
-        :content="minTooltipContent()"
-        placement="top"
-      >
-        <span
-          :class="isFastestMember === true ? 'fastest' : ''"
-        >{{ minSpan.duration | fixedMs }}/{{ minSpan.rep + 1 | ordinalise }}</span>
-      </el-tooltip>
+      <span
+        :class="isFastestMember === true ? 'fastest' : ''"
+      >{{ minSpan.duration | fixedMs }}/{{ minSpan.rep + 1 | ordinalise }}</span>
 
-      <el-tooltip
-        class="item"
-        effect="dark"
-        :content="medianTooltipContent()"
-        placement="top"
-      >
-        <span>{{ median | fixedMs }}/{{ reps }}</span>
-      </el-tooltip>
+      <span>{{ median | fixedMs }}/{{ reps }}</span>
 
-      <el-tooltip
-        class="item"
-        effect="dark"
-        :content="maxTooltipContent()"
-        placement="top"
-      >
-        <span
-          :class="isSlowestMember === true ? 'slowest' : ''"
-        >{{ maxSpan.duration | fixedMs }}/{{ maxSpan.rep + 1 | ordinalise }}</span>
-      </el-tooltip>
+      <span
+        :class="isSlowestMember === true ? 'slowest' : ''"
+      >{{ maxSpan.duration | fixedMs }}/{{ maxSpan.rep + 1 | ordinalise }}</span>
     </div>
     <div v-if="expaned">
       <step-line
@@ -179,27 +158,6 @@ export default {
       return this.childStepSpans.filter(
         childStepSpan => childStepSpan.name === childStepName,
       );
-    },
-
-    minTooltipContent() {
-      const { ordinalise } = this.$options.filters;
-      return `The ${ordinalise(
-        this.minSpan.rep + 1,
-      )} repetition of this step was the FASTEST.`;
-    },
-
-    maxTooltipContent() {
-      const { ordinalise } = this.$options.filters;
-      return `The ${ordinalise(
-        this.maxSpan.rep + 1,
-      )} repetition of this step was the SLOWEST.`;
-    },
-
-    medianTooltipContent() {
-      const { fixedMs } = this.$options.filters;
-      return `Among all ${this.reps} repetitions of this step, the median was ${fixedMs(
-        this.median,
-      )}.`;
     },
   },
 };

--- a/service/dashboard/src/views/inspect/TabularView/utils.js
+++ b/service/dashboard/src/views/inspect/TabularView/utils.js
@@ -1,0 +1,118 @@
+const getQueryCardChartOptions = (querySpans) => {
+  const queryCardChartOptions = {
+    tooltip: {
+      show: true,
+      trigger: 'item',
+    },
+    xAxis: {
+      type: 'category',
+      name: 'Time (ms)',
+      nameLocation: 'middle',
+      nameTextStyle: {
+        padding: [10, 0, 0, 0],
+      },
+      axisLabel: {
+        fontSize: 11,
+      },
+      data: [],
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Occurr.',
+      nameRotate: 90,
+      nameLocation: 'middle',
+      nameTextStyle: {
+        padding: [0, 0, 7, 0],
+      },
+      splitNumber: 2,
+      interval: 1,
+      axisLabel: {
+        fontSize: 11,
+      },
+    },
+    series: [
+      {
+        data: [],
+        type: 'bar',
+        barWidth: 20,
+        barCategoryGap: '10%',
+        tooltip: {
+          formatter: args => `${args.data.spans
+            .sort((a, b) => (a.duration > b.duration ? 1 : -1))
+            .map(span => `Rep ${span.rep + 1}: ${span.duration / 1000} ms`).join('<br>')}`,
+        },
+      },
+    ],
+    grid: {
+      left: 50,
+      top: 30,
+      right: 10,
+      bottom: 40,
+    },
+  };
+
+
+  let sortedSpansExceptFirst = querySpans;
+  sortedSpansExceptFirst.sort((a, b) => (a.duration > b.duration ? 1 : -1));
+  sortedSpansExceptFirst = sortedSpansExceptFirst.slice(0, -1);
+
+  const numOfBuckets = 4;
+  const minSpan = sortedSpansExceptFirst[0];
+  const minDuration = Math.floor(minSpan.duration / 1000);
+  const maxSpan = sortedSpansExceptFirst[sortedSpansExceptFirst.length - 1];
+  const maxDuration = Math.ceil(maxSpan.duration / 1000);
+  const minWidth = (maxDuration - minDuration) / numOfBuckets;
+  const bins = [];
+  let binCount = 0;
+  const interval = minWidth;
+
+  // Setup Bins
+  for (let i = minDuration; i < maxDuration; i += interval) {
+    bins.push({
+      binNum: binCount,
+      minNum: i,
+      maxNum: i + interval,
+      count: 0,
+      spans: [],
+    });
+    binCount += 1;
+  }
+
+  // Loop through data and add to bin's count
+  for (let m = 0; m < sortedSpansExceptFirst.length; m += 1) {
+    const span = sortedSpansExceptFirst[m];
+    const duration = span.duration / 1000;
+    for (let j = 0; j < bins.length; j += 1) {
+      const bin = bins[j];
+      if (duration > bin.minNum && duration <= bin.maxNum) {
+        bin.count += 1;
+        bin.spans.push(span);
+      }
+    }
+  }
+
+  const xData = [];
+  const seriesData = [];
+
+  for (let n = 0; n < bins.length; n += 1) {
+    if (n === bins.lengt - 1) {
+      xData.push(bins[n].maxNum);
+    } else {
+      xData.push(bins[n].minNum);
+    }
+    seriesData.push({
+      value: bins[n].count,
+      spans: bins[n].spans,
+    });
+  }
+
+  queryCardChartOptions.series[0].data = seriesData;
+  queryCardChartOptions.xAxis.data = xData;
+
+  return queryCardChartOptions;
+};
+
+
+export default {
+  getQueryCardChartOptions,
+};


### PR DESCRIPTION
## What is the goal of this PR?
In the QueryCard, adds:
- a histogram populated by repetitions of the query to illustrate the normality among the repetitions (the first repetition is excluded considering that it takes a significantly longer time), closes #215 
- the number of reps,
- the mean of durations,
- the median of durations, and
- the standard deviation of all durations.

In StepLine and GroupLine, removes the tooltips.

In Inspect, moves the ScaleSelector to the right.

## What are the changes implemented in this PR?
The major implementation of this PR is setting up the options (including data) for the histogram which can be found in `views/inspect/TabularView/utils.js`.
