### PR TITLE
Fixes bug with exclusion of first rep in histogram of QueryCard

### DIFF
--- a/service/dashboard/src/views/Inspect/components/QueryCard/index.vue
+++ b/service/dashboard/src/views/Inspect/components/QueryCard/index.vue
@@ -29,7 +29,7 @@
         >
           <div class="queryCardDetail">
             <p>
-              {{ spansSortedByRep[0].duration | fixedMs }} ms
+              {{ spanOfFirstRep.duration | fixedMs }} ms
             </p>
           </div>
         </el-tooltip>
@@ -187,9 +187,8 @@ export default {
   },
 
   computed: {
-    spansSortedByRep() {
-      const sortedSpans = this.querySpans;
-      return sortedSpans.sort((a, b) => (a.rep > b.reo ? 1 : -1));
+    spanOfFirstRep() {
+      return this.querySpans.filter(span => span.rep === 0)[0];
     },
 
     spansSortedByDuration() {
@@ -227,6 +226,8 @@ export default {
     }
 
     this.queryCardChartOptions = getQueryCardChartOptions(this.querySpans);
+
+    console.log(JSON.stringify(this.querySpans));
   },
 
   methods: {

--- a/service/dashboard/src/views/Inspect/components/QueryCard/index.vue
+++ b/service/dashboard/src/views/Inspect/components/QueryCard/index.vue
@@ -226,8 +226,6 @@ export default {
     }
 
     this.queryCardChartOptions = getQueryCardChartOptions(this.querySpans);
-
-    console.log(JSON.stringify(this.querySpans));
   },
 
   methods: {

--- a/service/dashboard/src/views/Inspect/components/QueryCard/util.js
+++ b/service/dashboard/src/views/Inspect/components/QueryCard/util.js
@@ -58,7 +58,7 @@ const getQueryCardChartOptions = (querySpans) => {
   // one single bin (most probably the first one), and the first repetition in the last bin. such histogram won't be insightful.
   let sortedSpansExceptFirst = querySpans;
   sortedSpansExceptFirst.sort((a, b) => (a.duration > b.duration ? 1 : -1));
-  sortedSpansExceptFirst = sortedSpansExceptFirst.slice(0, -1);
+  sortedSpansExceptFirst = sortedSpansExceptFirst.filter(span => span.rep !== 0);
 
   // dynamic calculation of number of bins is a difficult problem. no formula guarantees the "right" number of bins, specially when
   // dealing with small datasets. we may need to readjust this (hard-coded) as we increase the number of repetitions of queries, or


### PR DESCRIPTION
## What is the goal of this PR?
Makes sure that it's the first repetition of the query that's excluded from population of the histogram on the QueryCard.
