### PR TITLE
exclude outliers from QueryCard's histogram data

### DIFF
--- a/service/dashboard/src/util/math.js
+++ b/service/dashboard/src/util/math.js
@@ -1,0 +1,31 @@
+const getOutliers = (arr) => {
+  const medianIndex = getMedian(arr).index;
+  const lowerHalf = arr.slice(0, medianIndex);
+  const q1 = getMedian(lowerHalf).value;
+  const upperHalf = arr.slice(medianIndex);
+  const q3 = getMedian(upperHalf).value;
+  const qr = q3 - q1;
+  const upperBound = q3 + (1.5 * qr);
+  const lowerBound = q1 - (1.5 * qr);
+
+  return {
+    upper: arr.filter(item => item > upperBound),
+    lower: arr.filter(item => item < lowerBound),
+  };
+};
+
+const getMedian = (arr) => {
+  arr.sort((a, b) => (a > b ? 1 : -1));
+  const lowMiddleIndex = Math.floor((arr.length - 1) / 2);
+  const highMiddleIndex = Math.ceil((arr.length - 1) / 2);
+  return {
+    value: (arr[lowMiddleIndex] + arr[highMiddleIndex]) / 2,
+    index: lowMiddleIndex,
+  };
+};
+
+
+export default {
+  getOutliers,
+  getMedian,
+};

--- a/service/dashboard/src/views/Inspect/components/QueryCard/util.js
+++ b/service/dashboard/src/views/Inspect/components/QueryCard/util.js
@@ -1,4 +1,4 @@
-const getQueryCardChartOptions = (querySpans) => {
+const getQueryCardChartOptions = (spans) => {
   const queryCardChartOptions = {
     tooltip: {
       show: true,
@@ -51,21 +51,12 @@ const getQueryCardChartOptions = (querySpans) => {
     },
   };
 
-
-  // for the time being, because the first repetition of a query, takes a significantly longer time
-  // we have decided to not include it in populating the histogram.
-  // including it results in a very wide bin size which means every other repetition of that query would sit in
-  // one single bin (most probably the first one), and the first repetition in the last bin. such histogram won't be insightful.
-  let sortedSpansExceptFirst = querySpans;
-  sortedSpansExceptFirst.sort((a, b) => (a.duration > b.duration ? 1 : -1));
-  sortedSpansExceptFirst = sortedSpansExceptFirst.filter(span => span.rep !== 0);
-
   // dynamic calculation of number of bins is a difficult problem. no formula guarantees the "right" number of bins, specially when
   // dealing with small datasets. we may need to readjust this (hard-coded) as we increase the number of repetitions of queries, or
   // perhaps, allow the user to chose it as a parameter of the histogram.
   const numOfBins = 4;
-  const minDuration = Math.floor(sortedSpansExceptFirst[0].duration / 1000);
-  const maxDuration = Math.ceil(sortedSpansExceptFirst[sortedSpansExceptFirst.length - 1].duration / 1000);
+  const minDuration = Math.floor(spans[0].duration / 1000);
+  const maxDuration = Math.ceil(spans[spans.length - 1].duration / 1000);
   const binWidth = (maxDuration - minDuration) / numOfBins;
   const bins = [];
   let binCount = 0;
@@ -84,8 +75,8 @@ const getQueryCardChartOptions = (querySpans) => {
   }
 
   // populate each bin's count and spans
-  for (let i = 0; i < sortedSpansExceptFirst.length; i += 1) {
-    const span = sortedSpansExceptFirst[i];
+  for (let i = 0; i < spans.length; i += 1) {
+    const span = spans[i];
     const duration = span.duration / 1000;
 
     for (let j = 0; j < bins.length; j += 1) {


### PR DESCRIPTION
## What is the goal of this PR?
Previously, the histogram of QueryCard excluded the first repetitions of the query (with the assumption that the first repetition always took significantly longer). Turns out, for many queries that is not the case. As a part of this PR, the _outlier_ spans, if any, regardless of their repetitions number, are excluded. The outlier spans are displayed on the QueryCard, left of the histogram.

## What are the changes implemented in this PR?
`util/math.js` contains the implementation for identifying the outliers within an array of numbers. Moving forward, this file will act as a small math library.

`QueryCard.js` imports from `math.js` and uses `getMedian` and getOutliers` functions for obtaning the `histogramSpans` and `outlierSpans`.

