### PR TITLE
Simplifies the dashboard's URL

### DIFF
--- a/service/dashboard/package.json
+++ b/service/dashboard/package.json
@@ -37,7 +37,7 @@
   },
   "vue": {
     "devServer": {
-      "proxy": "http://35.231.146.169:4567"
+      "proxy": "http://35.237.252.2:80"
     },
     "lintOnSave": true
   }

--- a/service/deploy_web_server.sh
+++ b/service/deploy_web_server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+!/bin/bash
 
 # exit when any command fails
 set -e
@@ -14,8 +14,8 @@ fi
 
 echo "Getting to a clean web-server state on $INSTANCE_NAME..."
 
-# gcloud compute ssh ubuntu@$INSTANCE_NAME --zone=$ZONE --command='pkill node'
-gcloud compute ssh ubuntu@$INSTANCE_NAME --zone=$ZONE --command='rm -rf ~/service/web-server/'
+gcloud compute ssh ubuntu@$INSTANCE_NAME --zone=$ZONE --command='pkill node'
+gcloud compute ssh ubuntu@$INSTANCE_NAME --zone=$ZONE --command='sudo rm -rf ~/service/web-server/'
 
 echo "Uploading web-server files to $INSTANCE_NAME..."
 
@@ -24,4 +24,4 @@ gcloud compute scp --recurse web-server/src ubuntu@$INSTANCE_NAME:~/service/web-
 gcloud compute scp web-server/package.json ubuntu@$INSTANCE_NAME:~/service/web-server/ --zone=$ZONE
 
 echo "Start the updated web-server"
-gcloud compute ssh ubuntu@$INSTANCE_NAME --zone=$ZONE --command='cd ~/service/web-server && npm install && node ~/service/web-server/src/server.js 2>&1 | tee -a ~/logs/node_server.log'
+gcloud compute ssh ubuntu@$INSTANCE_NAME --zone=$ZONE --command='cd ~/service/web-server && sudo sudo npm install && sudo node ~/service/web-server/src/server.js 2>&1 | tee -a ~/logs/node_server.log'

--- a/service/deploy_web_server.sh
+++ b/service/deploy_web_server.sh
@@ -24,4 +24,4 @@ gcloud compute scp --recurse web-server/src ubuntu@$INSTANCE_NAME:~/service/web-
 gcloud compute scp web-server/package.json ubuntu@$INSTANCE_NAME:~/service/web-server/ --zone=$ZONE
 
 echo "Start the updated web-server"
-gcloud compute ssh ubuntu@$INSTANCE_NAME --zone=$ZONE --command='cd ~/service/web-server && sudo sudo npm install && sudo node ~/service/web-server/src/server.js 2>&1 | tee -a ~/logs/node_server.log'
+gcloud compute ssh ubuntu@$INSTANCE_NAME --zone=$ZONE --command='cd ~/service/web-server && sudo npm install && sudo node ~/service/web-server/src/server.js 2>&1 | tee -a ~/logs/node_server.log'

--- a/service/executor/execute.sh
+++ b/service/executor/execute.sh
@@ -4,7 +4,7 @@ report_failure() {
   curl --header "Content-Type: application/json" \
     --request POST \
     --data "{\"executionId\":\"$EXECUTION_ID\" }" \
-    http://$SERVICE_IP:4567/execution/failed
+    http://$SERVICE_IP:80/execution/failed
 
   exit 1
 }
@@ -69,7 +69,7 @@ echo "Notifying Benchmark Service /start"
 curl --header "Content-Type: application/json" \
     --request POST \
     --data "{\"executionId\":\"$EXECUTION_ID\" }" \
-    http://$SERVICE_IP:4567/execution/start
+    http://$SERVICE_IP:80/execution/start
 
 # -- write queries --
 ./benchmark --config ./scenario/road_network/road_config_write.yml --execution-name "$EXECUTION_ID" --elastic-uri $SERVICE_IP:9200
@@ -89,4 +89,4 @@ curl --header "Content-Type: application/json" \
 curl --header "Content-Type: application/json" \
     --request POST \
     --data "{\"executionId\":\"$EXECUTION_ID\", \"vmName\": \"$INSTANCE_NAME\"}" \
-    http://$SERVICE_IP:4567/execution/completed
+    http://$SERVICE_IP:80/execution/completed

--- a/service/launch_service.sh
+++ b/service/launch_service.sh
@@ -16,7 +16,7 @@ gcloud compute instances create $INSTANCE_NAME          \
     --machine-type n1-standard-1                        \
     --boot-disk-size 500GB                              \
     --zone $ZONE                                        \
-    --tags elastic-tcp-9200,benchmark-service-tcp-4567  \
+    --tags elastic-tcp-9200,http-server,https-server    \
     --service-account grakn-benchmark-189@grakn-dev.iam.gserviceaccount.com \
     --scopes https://www.googleapis.com/auth/cloud-platform
 

--- a/service/web-server/src/config.js
+++ b/service/web-server/src/config.js
@@ -5,6 +5,6 @@ config.web = {};
 
 config.es.host = 'localhost';
 config.es.port = 9200;
-config.web.port = process.env.WEB_PORT || 4567;
+config.web.port = process.env.WEB_PORT || 80;
 
 module.exports = config;

--- a/service/web-server/src/server.js
+++ b/service/web-server/src/server.js
@@ -191,7 +191,8 @@ function checkPullRequestIsMerged(req, res, next) {
 
 // Start http server only when invoked by script
 if (!module.parent) {
-    app.listen(config.web.port, () => console.log(`Grakn Benchmark Service listening on port ${config.web.port}!`));
+    // specifying the hostname, 2nd argument, forces the server to accept connections on IPv4 address
+    app.listen(config.web.port, "0.0.0.0", () => console.log(`Grakn Benchmark Service listening on port ${config.web.port}!`));
 }
 // Register shutdown hook to properly terminate connection to ES
 process.on('exit', () => { esClient.close(); });


### PR DESCRIPTION
## What is the goal of this PR?
Eliminates the need for entering the port within the URL when accessing the dashboard.

## What are the changes implemented in this PR?
- Changes the port 4567 to (the default) 80.
- Specifies the host within `app.listen` so that the server accept connections on an IPv4 address
