### PR TITLE
Updates the histogram of QueryCard upon changing the scale

### DIFF
--- a/service/dashboard/src/views/Inspect/components/QueryCard/index.vue
+++ b/service/dashboard/src/views/Inspect/components/QueryCard/index.vue
@@ -187,12 +187,14 @@ export default {
       stepsAndGroups: [],
 
       queryExpanded: this.expanded,
-
-      queryCardChartOptions: {},
     };
   },
 
   computed: {
+    queryCardChartOptions() {
+      return getQueryCardChartOptions(this.histogramSpans);
+    },
+
     spanOfFirstRep() {
       return this.querySpans.filter(span => span.rep === 0)[0];
     },
@@ -236,8 +238,6 @@ export default {
     if (this.expanded) {
       this.fetchStepSpans();
     }
-
-    this.queryCardChartOptions = getQueryCardChartOptions(this.histogramSpans);
   },
 
   methods: {

--- a/service/web-server/src/config.js
+++ b/service/web-server/src/config.js
@@ -4,7 +4,7 @@ config.es = {};
 config.web = {};
 config.auth = {};
 
-config.es.host= process.env.NODE_ENV === "production" ? "localhost" : "35.237.252.3";
+config.es.host= process.env.NODE_ENV === "production" ? "localhost" : "35.237.252.2";
 config.es.port = 9200;
 config.web.port = {
     http: 80,


### PR DESCRIPTION
## What is the goal of this PR?
Fixes a bug with the histogram not updating when changing the scale.

## What are the changes implemented in this PR?
- makes the `queryCardChartOptions` reactive by moving it into `computed` properties.
- modifies `web-server/src/config.js` to include the correct value for `config.es.host`
