### PR TITLE
Rename scenarios and update tags

### DIFF
--- a/common/configuration/scenario/biochemical_network/biochemical_config_read.yml
+++ b/common/configuration/scenario/biochemical_network/biochemical_config_read.yml
@@ -1,5 +1,5 @@
-name: "Biochemical Network - Read"
-description: "Benchmark relatively simple and dense biochemical network with: Increasing C_in, Increasing R_out, and Increasing A_out"
+name: "Biochemical Network"
+description: "Benchmark simple and dense biochemical network with: Increasing C_in, Increasing R_out, and Increasing A_out"
 dataGenerator: "biochemical_network"
 schema: "biochemical_network.gql"
 scales:

--- a/common/configuration/scenario/reasoning/config_read.yml
+++ b/common/configuration/scenario/reasoning/config_read.yml
@@ -1,4 +1,4 @@
-name: "Transitive Closure - Read"
+name: "Transitive Closure"
 description: "Simple chain of transitive relations"
 schema: "transitivity_schema.gql"
 dataImportFile: "transitivity_data.gql"

--- a/common/configuration/scenario/rule_scaling/config_read.yml
+++ b/common/configuration/scenario/rule_scaling/config_read.yml
@@ -1,4 +1,4 @@
-name: "Rule Scaling Test"
+name: "Rule Scaling"
 description: "Tests for query execution on graphs with large number of rules"
 schema: "rule_scaling_schema.gql"
 dataImportFile: "rule_scaling_data.gql"

--- a/profiler/src/QueryProfiler.java
+++ b/profiler/src/QueryProfiler.java
@@ -68,8 +68,9 @@ class QueryProfiler implements Runnable {
         executionName = config.executionName();
         deleteInsertedConcepts = config.deleteInsertedConcepts();
         traceDeleteInsertedConcepts = config.traceDeleteInsertedConcepts();
-        dataGenerator = config.generateData() ? config.dataGenerator() : "";
-        dataImport = config.staticDataImport() ? config.staticDataImportFilePath() : "";
+        dataGenerator = config.generateData() ? config.dataGenerator() : null;
+        dataImport = config.staticDataImport() ? config.staticDataImportFilePath() : null;
+
         this.concurrentId = concurrentId;
         this.tracer = tracer;
         this.queries = queries;
@@ -87,10 +88,9 @@ class QueryProfiler implements Runnable {
             concurrentExecutionSpan.tag("description", description);
             concurrentExecutionSpan.tag("executionName", executionName);
             concurrentExecutionSpan.tag("concurrentClient", Integer.toString(concurrentId));
-            concurrentExecutionSpan.tag("graphType", dataGenerator != null? dataGenerator : dataImport);
+            concurrentExecutionSpan.tag("graphType", dataGenerator != null ? dataGenerator : dataImport);
             concurrentExecutionSpan.tag("queryRepetitions", Integer.toString(repetitions));
             concurrentExecutionSpan.tag("graphScale", Integer.toString(numConcepts));
-            concurrentExecutionSpan.tag("configurationName", configName);
             concurrentExecutionSpan.start();
 
             System.out.println("Executing queries");


### PR DESCRIPTION
## What is the goal of this PR?
Dashboard overview's graph titles currently are not aesthetic - ending in `.gql` for instance, or requiring string processing to replace `_` with ` `. 

We can improve this by using the names of benchmark configurations rather than the `graphType`. This PR cleans up the configuration names and the zipkin tags that are stored in ES


## What are the changes implemented in this PR?
Rename config files and graph tags.