### PR TITLE
1 - Brings back the v-loading directive

### DIFF
--- a/service/dashboard/src/assets/css/elements/_index.scss
+++ b/service/dashboard/src/assets/css/elements/_index.scss
@@ -13,3 +13,4 @@
 @import "./tooltip";
 @import "./table";
 @import "./list_group";
+@import "./spinner";

--- a/service/dashboard/src/assets/css/elements/_spinner.scss
+++ b/service/dashboard/src/assets/css/elements/_spinner.scss
@@ -1,0 +1,13 @@
+@import "../vendors/bootstrap-4.3.1/scss/spinners";
+
+.spinner-grow, .spinner-border {
+    &.centered {
+        margin-top: calc(-#{$spinner-height} / 2);
+        margin-left: calc(-#{$spinner-width} / 2);
+    }
+
+    &-sm.centered {
+        margin-top: calc(-#{$spinner-height-sm} / 2);
+        margin-left: calc(-#{$spinner-width-sm} / 2);
+    }
+}

--- a/service/dashboard/src/assets/css/global.scss
+++ b/service/dashboard/src/assets/css/global.scss
@@ -26,3 +26,10 @@ a {
     flex-direction: column;
   }
 }
+
+.centered {
+  display: block;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+}

--- a/service/dashboard/src/main.js
+++ b/service/dashboard/src/main.js
@@ -4,6 +4,7 @@ import { library } from '@fortawesome/fontawesome-svg-core';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import { faTachometerAlt, faListAlt } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import loadingDirective from '@/plugins/vue-loading';
 import App from './App.vue';
 import router from './router';
 import './util/filters';
@@ -13,6 +14,7 @@ library.add(faGithub, faTachometerAlt, faListAlt);
 
 Vue.component('font-awesome-icon', FontAwesomeIcon);
 Vue.use(BootstrapVue);
+Vue.use(loadingDirective);
 
 Vue.config.productionTip = false;
 

--- a/service/dashboard/src/plugins/vue-loading/index.js
+++ b/service/dashboard/src/plugins/vue-loading/index.js
@@ -1,0 +1,118 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-shadow */
+import Loading from './loading.vue';
+import {
+  addClass,
+  removeClass,
+  getStyle,
+} from './util/dom';
+import afterLeave from './util/after-leave';
+
+const loadingDirective = {};
+loadingDirective.install = (Vue, options) => {
+  const Mask = Vue.extend(Loading);
+  const insertDom = (parent, el, binding) => {
+    const options = binding.value;
+    if (!el.domVisible
+      && getStyle(el, 'display') !== 'none'
+      && getStyle(el, 'visibility') !== 'hidden'
+    ) {
+      Object.keys(el.maskStyle).forEach((property) => {
+        el.mask.style[property] = el.maskStyle[property];
+      });
+
+      if (el.originalPosition !== 'absolute' && el.originalPosition !== 'fixed') {
+        addClass(parent, 'loading-parent--relative');
+      }
+      if (options.fullscreen) {
+        addClass(parent, 'loading-parent--hidden');
+      }
+      el.domVisible = true;
+
+      parent.appendChild(el.mask);
+      Vue.nextTick(() => {
+        if (el.instance.hiding) {
+          el.instance.$emit('after-leave');
+        } else {
+          el.instance.visible = true;
+        }
+      });
+      el.domInserted = true;
+    }
+  };
+  const toggleLoading = (el, binding) => {
+    const options = binding.value;
+    if (options.show) {
+      Vue.nextTick(() => {
+        if (options.fullscreen) {
+          el.originalPosition = getStyle(document.body, 'position');
+          el.originalOverflow = getStyle(document.body, 'overflow');
+          el.maskStyle.zIndex = options.zIndex;
+          addClass(el.mask, 'is-fullscreen');
+          insertDom(document.body, el, binding);
+        } else {
+          removeClass(el.mask, 'is-fullscreen');
+          el.originalPosition = getStyle(el, 'position');
+          insertDom(el, el, binding);
+        }
+      });
+    } else {
+      afterLeave(
+        el.instance,
+        () => {
+          const options = binding.value;
+          el.domVisible = false;
+          const target = options.fullscreen ? document.body : el;
+          removeClass(target, 'loading-parent--relative');
+          removeClass(target, 'loading-parent--hidden');
+          el.instance.hiding = false;
+        },
+        300,
+        true,
+      );
+      el.instance.visible = false;
+      el.instance.hiding = true;
+    }
+  };
+
+  Vue.directive('loading', {
+    bind(el, binding, vnode) {
+      const options = binding.value;
+      const mask = new Mask({
+        el: document.createElement('div'),
+        data: {
+          text: options.text || '',
+          background: options.background || '',
+          customClass: options.customClass || '',
+          fullscreen: options.fullscreen || false,
+        },
+      });
+      el.instance = mask;
+      el.mask = mask.$el;
+      el.maskStyle = {};
+      if (options.show) {
+        toggleLoading(el, binding);
+      }
+    },
+
+    update(el, binding) {
+      const options = binding.value;
+      el.instance.setText(options.text);
+      toggleLoading(el, binding);
+    },
+
+    unbind(el, binding) {
+      if (el.domInserted) {
+        if (el.mask && el.mask.parentNode) {
+          el.mask.parentNode.removeChild(el.mask);
+        }
+        toggleLoading(el, {
+          value: false,
+          modifiers: binding,
+        });
+      }
+    },
+  });
+};
+
+export default loadingDirective;

--- a/service/dashboard/src/plugins/vue-loading/loading.vue
+++ b/service/dashboard/src/plugins/vue-loading/loading.vue
@@ -1,0 +1,69 @@
+<template>
+  <transition
+    name="loading-fade"
+    @after-leave="handleAfterLeave"
+  >
+    <div
+      v-show="visible"
+      :style="{ backgroundColor: background || '' }"
+      :class="[customClass, { 'is-fullscreen': fullscreen }]"
+      class="loading-mask"
+    >
+      <b-spinner
+        label="Spinning"
+        class="centered"
+      />
+    </div>
+  </transition>
+</template>
+
+<script>
+import { BSpinner } from 'bootstrap-vue';
+
+export default {
+  components: { BSpinner },
+  data() {
+    return {
+      text: 'cfcvf',
+      background: null,
+      fullscreen: true,
+      visible: false,
+      customClass: '',
+    };
+  },
+
+  methods: {
+    handleAfterLeave() {
+      this.$emit('after-leave');
+    },
+
+    setText(text) {
+      this.text = text;
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.loading-mask {
+  position: absolute;
+  z-index: 20;
+  background-color: rgba(255, 255, 255, 0.9);
+  margin: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  transition: opacity 0.4s;
+  &.is-fullscreen {
+    position: fixed;
+  }
+}
+
+.loading-parent--relative {
+  position: relative !important;
+}
+.loading-parent--hidden {
+  overflow: hidden !important;
+}
+</style>

--- a/service/dashboard/src/plugins/vue-loading/util/after-leave.js
+++ b/service/dashboard/src/plugins/vue-loading/util/after-leave.js
@@ -1,0 +1,31 @@
+/**
+ * Bind after-leave event for vue instance. Make sure after-leave is called in any browsers.
+ *
+ * @param {Vue} instance Vue instance.
+ * @param {Function} callback callback of after-leave event
+ * @param {Number} speed the speed of transition, default value is 300ms
+ * @param {Boolean} once weather bind after-leave once. default value is false.
+ */
+export default function (instance, callback, speed = 300, once = false) {
+  if (!instance || !callback) {
+    throw new Error('instance & callback is required');
+  }
+  let called = false;
+
+  function afterLeaveCallback() {
+    if (called) return;
+    called = true;
+    if (callback) {
+      callback();
+    }
+  }
+
+  if (once) {
+    instance.$once('after-leave', afterLeaveCallback);
+  } else {
+    instance.$on('after-leave', afterLeaveCallback);
+  }
+  setTimeout(() => {
+    afterLeaveCallback();
+  }, speed + 100);
+}

--- a/service/dashboard/src/plugins/vue-loading/util/dom.js
+++ b/service/dashboard/src/plugins/vue-loading/util/dom.js
@@ -1,0 +1,100 @@
+/* eslint-disable func-names */
+/* eslint-disable no-param-reassign */
+// eslint-disable-next-line no-useless-escape
+const SPECIAL_CHARS_REGEXP = /([\:\-\_]+(.))/g;
+const MOZ_HACK_REGEXP = /^moz([A-Z])/;
+
+const trim = function (string) {
+  return (string || '').replace(/^[\s\uFEFF]+|[\s\uFEFF]+$/g, '');
+};
+
+const camelCase = function (name) {
+  return name
+    .replace(SPECIAL_CHARS_REGEXP, (_, separator, letter, offset) => {
+      if (offset) {
+        return letter.toUpperCase();
+      }
+      return letter;
+    })
+    .replace(MOZ_HACK_REGEXP, 'Moz$1');
+};
+
+export function hasClass(el, cls) {
+  if (!el || !cls) return false;
+  if (cls.indexOf(' ') !== -1) {
+    throw new Error('className should not contain space.');
+  }
+  if (el.classList) {
+    return el.classList.contains(cls);
+  }
+  return ` ${el.className} `.indexOf(` ${cls} `) > -1;
+}
+
+export function addClass(el, cls) {
+  if (!el) return;
+  let curClass = el.className;
+  const classes = (cls || '').split(' ');
+
+  for (let i = 0, j = classes.length; i < j; i += 1) {
+    const clsName = classes[i];
+    // if (!clsName) continue;
+
+    if (el.classList) {
+      el.classList.add(clsName);
+    } else if (!hasClass(el, clsName)) {
+      curClass += ` ${clsName}`;
+    }
+  }
+  if (!el.classList) {
+    el.className = curClass;
+  }
+}
+
+export function removeClass(el, cls) {
+  if (!el || !cls) return;
+  const classes = cls.split(' ');
+  let curClass = ` ${el.className} `;
+
+  for (let i = 0, j = classes.length; i < j; i += 1) {
+    const clsName = classes[i];
+    // if (!clsName) continue;
+
+    if (el.classList) {
+      el.classList.remove(clsName);
+    } else if (hasClass(el, clsName)) {
+      curClass = curClass.replace(` ${clsName} `, ' ');
+    }
+  }
+  if (!el.classList) {
+    el.className = trim(curClass);
+  }
+}
+
+export const getStyle = function (element, styleName) {
+  if (!element || !styleName) return null;
+  styleName = camelCase(styleName);
+  if (styleName === 'float') {
+    styleName = 'cssFloat';
+  }
+  try {
+    const computed = document.defaultView.getComputedStyle(element, '');
+    return element.style[styleName] || computed ? computed[styleName] : null;
+  } catch (e) {
+    return element.style[styleName];
+  }
+};
+
+export function setStyle(element, styleName, value) {
+  if (!element || !styleName) return;
+
+  if (typeof styleName === 'object') {
+    Object.keys(styleName).forEach((key) => {
+      if (Object.prototype.hasOwnProperty.call(styleName, key)) {
+        setStyle(element, key, styleName[key]);
+      }
+    });
+  } else {
+    styleName = camelCase(styleName);
+    element.style[styleName] = value;
+  }
+}

--- a/service/dashboard/src/views/Executions/index.vue
+++ b/service/dashboard/src/views/Executions/index.vue
@@ -91,7 +91,10 @@ export default {
   components: { SortbySelector, ExecutionCard },
   data() {
     return {
-      loading: true,
+      loading: {
+        show: true,
+        fullscreen: true,
+      },
 
       // popoverVisible: false,
 
@@ -148,7 +151,7 @@ export default {
       );
       this.executions = executionsResp.data.executions;
       this.sortExecutions(this.sortColumn);
-      this.loading = false;
+      this.loading.show = false;
     },
 
     sortExecutions(column) {

--- a/service/dashboard/src/views/Inspect/components/QueryCard/index.vue
+++ b/service/dashboard/src/views/Inspect/components/QueryCard/index.vue
@@ -127,7 +127,9 @@ export default {
 
   data() {
     return {
-      loading: false,
+      loading: {
+        show: false,
+      },
 
       stepSpans: [],
 
@@ -238,7 +240,7 @@ export default {
     },
 
     async toggleStepsTable() {
-      this.loading = true;
+      this.loading.show = true;
 
       if (!this.stepsAndGroups.length) {
         await this.fetchStepSpans();
@@ -246,7 +248,7 @@ export default {
 
       this.queryExpanded = !this.queryExpanded;
 
-      this.loading = false;
+      this.loading.show = false;
     },
 
     async fetchStepSpans() {

--- a/service/dashboard/src/views/overview/components/ChartCommits/index.vue
+++ b/service/dashboard/src/views/overview/components/ChartCommits/index.vue
@@ -94,7 +94,10 @@ export default {
 
       querySpans: [],
 
-      loading: true,
+      loading: {
+        show: true,
+        fullscreen: true,
+      },
 
       commitsChart: null,
 
@@ -147,7 +150,7 @@ export default {
   methods: {
     onScaleSelection(scale) {
       this.selectedScale = scale;
-      this.loading = true;
+      this.loading.show = true;
     },
 
     redirectToInspect(args) {
@@ -171,7 +174,7 @@ export default {
         this.executions,
         this.selectedScale,
       );
-      this.loading = false;
+      this.loading.show = false;
     },
 
     toggleChartQueryType(selectedQueryTypes) {


### PR DESCRIPTION
## What is the goal of this PR?
After moving from `element-ui` to `vue-bootstrap`, bootstrap's alternative (spinner) _alone_ offers little of what `v-loading` of element ui used to provide us. This PR brings back the functionality of `v-loading` and uses bootstrap's spinner for its presentation.

## What are the changes implemented in this PR?
- uses [vue-loading](https://github.com/jsercao/vue-loading)
- customises the source code of `vue-loading` to use bootstrap's `<b-spinner />`
- modifies the components that make use of the `v-loading` directive to adapt the enhanced configuration of it
