### PR TITLE
General refactoring of dashboard components

### DIFF
--- a/service/dashboard/.eslintrc.js
+++ b/service/dashboard/.eslintrc.js
@@ -26,5 +26,6 @@ module.exports = {
     'no-use-before-define': 0,
     'import/no-unresolved': 0,
     'no-param-reassign': ['error', { props: false }],
+    'import/prefer-default-export': 0,
   },
 };

--- a/service/dashboard/src/util/math.js
+++ b/service/dashboard/src/util/math.js
@@ -1,31 +1,35 @@
-const getOutliers = (arr) => {
-  const medianIndex = getMedian(arr).index;
-  const lowerHalf = arr.slice(0, medianIndex);
+export const getOutliers = (numbers) => {
+  const medianIndex = getMedian(numbers).index;
+  const lowerHalf = numbers.slice(0, medianIndex);
   const q1 = getMedian(lowerHalf).value;
-  const upperHalf = arr.slice(medianIndex);
+  const upperHalf = numbers.slice(medianIndex);
   const q3 = getMedian(upperHalf).value;
   const qr = q3 - q1;
   const upperBound = q3 + (1.5 * qr);
   const lowerBound = q1 - (1.5 * qr);
 
   return {
-    upper: arr.filter(item => item > upperBound),
-    lower: arr.filter(item => item < lowerBound),
+    upper: numbers.filter(item => item > upperBound),
+    lower: numbers.filter(item => item < lowerBound),
   };
 };
 
-const getMedian = (arr) => {
-  arr.sort((a, b) => (a > b ? 1 : -1));
-  const lowMiddleIndex = Math.floor((arr.length - 1) / 2);
-  const highMiddleIndex = Math.ceil((arr.length - 1) / 2);
+export const getMedian = (numbers) => {
+  numbers.sort((a, b) => (a > b ? 1 : -1));
+  const lowMiddleIndex = Math.floor((numbers.length - 1) / 2);
+  const highMiddleIndex = Math.ceil((numbers.length - 1) / 2);
   return {
-    value: (arr[lowMiddleIndex] + arr[highMiddleIndex]) / 2,
+    value: (numbers[lowMiddleIndex] + numbers[highMiddleIndex]) / 2,
     index: lowMiddleIndex,
   };
 };
 
+export const getMean = numbers => getSum(numbers) / numbers.length;
 
-export default {
-  getOutliers,
-  getMedian,
+export const getStdDeviation = (numbers) => {
+  const mean = getMean(numbers);
+  const sum = getSum(numbers.map(number => (number - mean) ** 2));
+  return Math.sqrt(sum / numbers.length);
 };
+
+const getSum = numbers => numbers.reduce((a, b) => a + b, 0);

--- a/service/dashboard/src/views/Inspect/components/GraphTab/index.vue
+++ b/service/dashboard/src/views/Inspect/components/GraphTab/index.vue
@@ -80,8 +80,14 @@ export default {
   },
 
   created() {
-    this.scales = [...new Set(this.graphs.map(graph => graph.scale))].sort((a, b) => a - b);
+    this.scales = this.getScales();
     this.selectedScale = this.preSelectedScale || this.scales[0];
+  },
+
+  methods: {
+    getScales() {
+      return [...new Set(this.graphs.map(graph => graph.scale))].sort();
+    },
   },
 };
 </script>

--- a/service/dashboard/src/views/Inspect/components/GraphTabs/index.vue
+++ b/service/dashboard/src/views/Inspect/components/GraphTabs/index.vue
@@ -1,14 +1,11 @@
 <template>
-  <div
-    v-if="graphs && querySpans"
-    class="graph-tabs-wrapper"
-  >
+  <div class="graph-tabs-wrapper">
     <b-tabs>
       <b-tab
         v-for="graphType in graphTypes"
         :key="graphType"
         :title="graphType"
-        :active="graphType === activeGraph"
+        :active="graphType === activeGraphType"
       >
         <graph-tab
           :query-spans="filterQuerySpans(graphType)"
@@ -33,14 +30,12 @@ export default {
   props: {
     graphs: {
       type: Array,
-      required: false,
-      default: null,
+      required: true,
     },
 
     querySpans: {
       type: Array,
-      required: false,
-      default: null,
+      required: true,
     },
 
     preSelectedGraphType: {
@@ -64,13 +59,10 @@ export default {
 
   computed: {
     graphTypes() {
-      const uniqueGraphTypes = [
-        ...new Set(this.graphs.map(graph => graph.type)),
-      ];
-      return uniqueGraphTypes;
+      return [...new Set(this.graphs.map(graph => graph.type))];
     },
 
-    activeGraph() {
+    activeGraphType() {
       return this.preSelectedGraphType || this.graphTypes[0];
     },
   },
@@ -95,15 +87,11 @@ export default {
     },
 
     getPreSelectedScale(graphType) {
-      if (this.preSelectedGraphType === graphType) return this.preSelectedScale;
-      return null;
+      return (this.preSelectedGraphType === graphType ? this.preSelectedScale : null);
     },
 
     getPreSelectedQuery(graphType) {
-      if (this.preSelectedGraphType === graphType) {
-        return this.preSelectedQuery;
-      }
-      return null;
+      return ((this.preSelectedGraphType === graphType) ? this.preSelectedQuery : null);
     },
   },
 };

--- a/service/dashboard/src/views/Inspect/components/GroupLine/index.vue
+++ b/service/dashboard/src/views/Inspect/components/GroupLine/index.vue
@@ -43,6 +43,7 @@
 <script>
 import ordinal from 'ordinal';
 import StepLine from '../StepLine';
+import { getMedian } from '@/util/math';
 
 export default {
   name: 'GroupLine',
@@ -122,13 +123,8 @@ export default {
     },
 
     median() {
-      const lowMiddleIndex = Math.floor((this.durationSortedMemberSpans.length - 1) / 2);
-      const highMiddleIndex = Math.ceil((this.durationSortedMemberSpans.length - 1) / 2);
-      return (
-        (this.durationSortedMemberSpans[lowMiddleIndex].duration
-          + this.durationSortedMemberSpans[highMiddleIndex].duration)
-        / 2
-      );
+      const dueations = this.memberSpans.map(span => span.duration);
+      return getMedian(dueations).value;
     },
   },
 

--- a/service/dashboard/src/views/Inspect/components/GroupLine/index.vue
+++ b/service/dashboard/src/views/Inspect/components/GroupLine/index.vue
@@ -97,17 +97,17 @@ export default {
       return Object.values(this.members).flat();
     },
 
-    firstMemberOrder() { // used in finding the correct index of a span among all members
-      return Object.keys(this.members).sort((a, b) => (parseInt(a, 0) > parseInt(b, 0) ? 1 : -1))[0];
+    orderOfFirstMember() {
+      return Object.keys(this.members).map(key => parseInt(key, 0)).sort()[0] + 1;
     },
 
-    durationSortedMemberSpans() {
+    memberSpansSortedByDuration() {
       const spans = this.memberSpans;
       return spans.sort((a, b) => (a.duration > b.duration ? 1 : -1));
     },
 
     minSpan() {
-      return this.durationSortedMemberSpans[0];
+      return this.memberSpansSortedByDuration[0];
     },
 
     indexOfMinSpan() {
@@ -115,7 +115,7 @@ export default {
     },
 
     maxSpan() {
-      return this.durationSortedMemberSpans[this.durationSortedMemberSpans.length - 1];
+      return this.memberSpansSortedByDuration[this.memberSpansSortedByDuration.length - 1];
     },
 
     indexOfMaxSpan() {
@@ -136,15 +136,15 @@ export default {
     },
 
     getIndexForSpan(order) {
-      return order - this.firstMemberOrder + 1;
+      return order - this.orderOfFirstMember;
     },
 
     isSpanFastest(order) {
-      return this.indexOfMinSpan === order - this.firstMemberOrder + 1;
+      return this.indexOfMinSpan === order - this.orderOfFirstMember;
     },
 
     isSpanSlowest(order) {
-      return this.indexOfMaxSpan === order - this.firstMemberOrder + 1;
+      return this.indexOfMaxSpan === order - this.orderOfFirstMember;
     },
   },
 };

--- a/service/dashboard/src/views/Inspect/components/QueryCard/index.vue
+++ b/service/dashboard/src/views/Inspect/components/QueryCard/index.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- <b-container fluid> -->
   <div
-    ref="expanded"
+    :ref="queryExpanded ? 'expanded' : ''"
     :class="'query-card ' + (queryExpanded ? 'expanded' : '')"
   >
     <div
@@ -84,20 +84,15 @@
 </template>
 
 <script>
+import EChart from 'vue-echarts';
 import BenchmarkClient from '@/util/BenchmarkClient';
 import StepsTable from '../StepsTable';
-import EChart from 'vue-echarts';
 import 'echarts/lib/chart/bar';
 import 'echarts/lib/component/tooltip';
-import EDF from '@/util/ExecutionDataFormatters';
-import util from './util';
-import math from '@/util/math';
+import { flattenStepSpans, attachRepsToChildSpans } from '@/util/ExecutionDataFormatters';
+import { getQueryCardChartOptions } from './util';
+import { getMedian, getOutliers } from '@/util/math';
 
-const { getMedian, getOutliers } = math;
-
-const { getQueryCardChartOptions } = util;
-
-const { flattenStepSpans, attachRepsToChildSpans } = EDF;
 
 export default {
   components: { EChart, StepsTable },
@@ -127,7 +122,7 @@ export default {
 
   data() {
     return {
-      loading: false,
+      loading: { show: false },
 
       stepSpans: [],
 

--- a/service/dashboard/src/views/Inspect/components/QueryCard/index.vue
+++ b/service/dashboard/src/views/Inspect/components/QueryCard/index.vue
@@ -42,7 +42,7 @@
                 v-for="span in outlierSpans"
                 :key="span.rep"
               >
-                Rep {{ span.rep + 1 }}: {{ span.duration | fixedMs }} ms
+                Rep {{ span.rep + 1 }}: {{ fixedMs(span.duration) }} ms
               </p>
             </div>
           </div>
@@ -99,12 +99,6 @@ import {
 export default {
   components: { EChart, StepsTable },
 
-  filters: {
-    fixedMs(num) {
-      return `${Number(num / 1000).toFixed(3)}`;
-    },
-  },
-
   props: {
     query: {
       type: String,
@@ -132,6 +126,7 @@ export default {
 
       queryExpanded: this.expanded,
 
+      // used within the component that fills the right-side panel (e.g. stepsTable) to be set as the max-height of the relevant element
       expandedSummaryHeight: 0,
     };
   },
@@ -164,12 +159,14 @@ export default {
       ];
     },
 
-    queryCardChartOptions() {
-      return getQueryCardChartOptions(this.histogramSpans);
+    histogramSpans() {
+      return this.querySpans
+        .filter(duration => !this.outlierSpans.includes(duration))
+        .sort((a, b) => (a.duration > b.duration ? 1 : -1));
     },
 
-    spanOfFirstRep() {
-      return this.querySpans.filter(span => span.rep === 0)[0];
+    queryCardChartOptions() {
+      return getQueryCardChartOptions(this.histogramSpans);
     },
 
     spansSortedByDuration() {

--- a/service/dashboard/src/views/Inspect/components/QueryCard/index.vue
+++ b/service/dashboard/src/views/Inspect/components/QueryCard/index.vue
@@ -251,51 +251,7 @@ export default {
       stepSpans = flattenStepSpans(stepSpans);
       this.stepSpans = attachRepsToChildSpans(stepSpans, this.querySpans);
 
-      this.produceStepsAndGroups();
-    },
-
-    /**
-     * iterates over fetched stepSpans to find out which spans should belong to a "group"
-     * the group object has one key i.e. 'members'
-     * 'members' is an object where:
-     *    - keys are the distinct 'order' of its members
-     *    - values are array of span objects
-     */
-    produceStepsAndGroups() {
-      const steps = this.stepSpans.filter(span => span.rep === 0);
-      steps.sort((a, b) => a.order - b.order);
-
-      let currentStep = steps[0];
-      let currentSteps = [];
-      let i = 0;
-
-      do {
-        if (steps[i].name === currentStep.name) {
-          currentSteps.push(steps[i]);
-          i += 1;
-        } else {
-          const stepOrGroup = this.buildStepOrGroup(currentSteps);
-          this.stepsAndGroups.push(stepOrGroup);
-          currentStep = steps[i];
-          currentSteps = [];
-        }
-      } while (i < steps.length);
-
-      // last step is not a group. insert it.
-      this.stepsAndGroups.push(steps[steps.length - 1]);
-    },
-
-    buildStepOrGroup(grouppedSteps) {
-      if (grouppedSteps.length > 1) {
-        const group = { members: {} };
-        grouppedSteps.forEach((grouppedStep) => {
-          group.members[grouppedStep.order] = this.filterStepSpans(
-            grouppedStep.order,
-          );
-        });
-        return group;
-      }
-      return grouppedSteps[0];
+      produceStepsAndGroups(this.stepSpans, this.stepsAndGroups, this.filterStepSpans);
     },
 
     filterStepSpans(stepNumber) {

--- a/service/dashboard/src/views/Inspect/components/QueryCard/util.js
+++ b/service/dashboard/src/views/Inspect/components/QueryCard/util.js
@@ -1,4 +1,4 @@
-const getQueryCardChartOptions = (spans) => {
+export const getQueryCardChartOptions = (spans) => {
   const queryCardChartOptions = {
     tooltip: {
       show: true,
@@ -109,9 +109,4 @@ const getQueryCardChartOptions = (spans) => {
   queryCardChartOptions.xAxis.data = xData;
 
   return queryCardChartOptions;
-};
-
-
-export default {
-  getQueryCardChartOptions,
 };

--- a/service/dashboard/src/views/Inspect/components/QueryCards/index.vue
+++ b/service/dashboard/src/views/Inspect/components/QueryCards/index.vue
@@ -4,7 +4,7 @@
       v-for="query in queries"
       :key="query"
       :query="query"
-      :query-spans="getQuerySpans(query)"
+      :query-spans="filterQuerySpans(query)"
       :expanded="query === preSelectedQuery"
     />
   </div>
@@ -38,7 +38,7 @@ export default {
   },
 
   methods: {
-    getQuerySpans(queryValue) {
+    filterQuerySpans(queryValue) {
       return this.scaledQuerySpans.filter(querySpan => querySpan.value === queryValue);
     },
   },

--- a/service/dashboard/src/views/Inspect/components/StepLine/index.vue
+++ b/service/dashboard/src/views/Inspect/components/StepLine/index.vue
@@ -140,25 +140,23 @@ export default {
       let childStepSpans = childStepSpansResp.data.childrenSpans;
       childStepSpans = flattenStepSpans(childStepSpans, this.stepSpans);
 
-      this.childStepSpans = attachRepsToChildSpans(
-        childStepSpans,
-        this.stepSpans,
-      );
+      this.childStepSpans = attachRepsToChildSpans(childStepSpans, this.stepSpans);
 
       if (this.childStepSpans.length) {
         const { parentId } = this.childStepSpans[0];
 
-        this.childStepNames = this.childStepSpans
-          .filter(childStepSpan => childStepSpan.parentId === parentId)
+        this.childStepNames = this.filterChildStepNames(parentId)
           .sort((a, b) => a.timestamp > b.timestamp)
           .map(childStepSpan => childStepSpan.name);
       }
     },
 
     filterChildStepSpans(childStepName) {
-      return this.childStepSpans.filter(
-        childStepSpan => childStepSpan.name === childStepName,
-      );
+      return this.childStepSpans.filter(childStepSpan => childStepSpan.name === childStepName);
+    },
+
+    filterChildStepNames(parentId) {
+      return this.childStepSpans.filter(childStepSpan => childStepSpan.parentId === parentId);
     },
   },
 };

--- a/service/dashboard/src/views/Inspect/components/StepLine/index.vue
+++ b/service/dashboard/src/views/Inspect/components/StepLine/index.vue
@@ -38,11 +38,10 @@
 </template>
 
 <script>
-import BenchmarkClient from '@/util/BenchmarkClient';
-import EDF from '@/util/ExecutionDataFormatters';
 import ordinal from 'ordinal';
-
-const { flattenStepSpans, attachRepsToChildSpans } = EDF;
+import BenchmarkClient from '@/util/BenchmarkClient';
+import { flattenStepSpans, attachRepsToChildSpans } from '@/util/ExecutionDataFormatters';
+import { getMedian } from '@/util/math';
 
 export default {
   name: 'StepLine',
@@ -115,13 +114,8 @@ export default {
     },
 
     median() {
-      const lowMiddleIndex = Math.floor((this.sortedSpans.length - 1) / 2);
-      const highMiddleIndex = Math.ceil((this.sortedSpans.length - 1) / 2);
-      return (
-        (this.sortedSpans[lowMiddleIndex].duration
-          + this.sortedSpans[highMiddleIndex].duration)
-        / 2
-      );
+      const dueations = this.sortedSpans.map(span => span.duration);
+      return getMedian(dueations).value;
     },
 
     reps() {

--- a/service/dashboard/src/views/Inspect/index.vue
+++ b/service/dashboard/src/views/Inspect/index.vue
@@ -2,19 +2,20 @@
   <section>
     <div v-if="execution">
       <execution-card
-        class="execution-card"
         :execution="execution"
         :columns="executionColumns"
       />
     </div>
 
-    <graph-tabs
-      :graphs="graphs"
-      :query-spans="querySpans"
-      :pre-selected-graph-type="preSelectedGraphType"
-      :pre-selected-query="preSelectedQuery"
-      :pre-selected-scale="preSelectedScale"
-    />
+    <div v-if="graphs && querySpans">
+      <graph-tabs
+        :graphs="graphs"
+        :query-spans="querySpans"
+        :pre-selected-graph-type="preSelectedGraphType"
+        :pre-selected-query="preSelectedQuery"
+        :pre-selected-scale="preSelectedScale"
+      />
+    </div>
   </section>
 </template>
 

--- a/service/dashboard/src/views/overview/components/ChartCommits/index.vue
+++ b/service/dashboard/src/views/overview/components/ChartCommits/index.vue
@@ -36,19 +36,16 @@
 </template>
 
 <script>
-import BenchmarkClient from '@/util/BenchmarkClient';
-import Util from './util';
 import EChart from 'vue-echarts';
+import BenchmarkClient from '@/util/BenchmarkClient';
+import { getCommitsChartOptions, getLegendsData } from './util';
 import 'echarts/lib/chart/line';
 import 'echarts/lib/component/tooltip';
 import 'echarts/lib/component/legend';
 import 'echarts/lib/component/legendScroll';
 import 'echarts/lib/component/dataZoom';
 import ScaleSelector from '@/components/Selector.vue';
-import EDF from '@/util/ExecutionDataFormatters';
-
-const { getCommitsChartOptions, getLegendsData } = Util;
-const { flattenQuerySpans } = EDF;
+import { flattenQuerySpans } from '@/util/ExecutionDataFormatters';
 
 export default {
   /* eslint-disable guard-for-in */

--- a/service/dashboard/src/views/overview/components/ChartCommits/util.js
+++ b/service/dashboard/src/views/overview/components/ChartCommits/util.js
@@ -2,7 +2,7 @@ import EDF from '@/util/ExecutionDataFormatters';
 
 const { addExecutionIdAndScaleToQuerySpan } = EDF;
 
-const getCommitsChartOptions = async (graphs, querySpans, queries, executions, selectedScale) => {
+export const getCommitsChartOptions = async (graphs, querySpans, queries, executions, selectedScale) => {
   const querySpansWithExecutionAndScale = addExecutionIdAndScaleToQuerySpan(
     graphs,
     querySpans,
@@ -114,7 +114,7 @@ const getCommitsChartOptions = async (graphs, querySpans, queries, executions, s
 };
 
 /* eslint-disable no-plusplus */
-function getLegendsData(queries) {
+export const getLegendsData = (queries) => {
   let matchQuery = 0;
   // const matchInsertQuery = 0;
   let insertQuery = 0;
@@ -139,18 +139,16 @@ function getLegendsData(queries) {
     queriesMap[query] = value;
   });
   return queriesMap;
-}
+};
 
-function computeAvgTime(spans) {
-  return spans.reduce((a, b) => a + b.duration, 0) / spans.length;
-}
+const computeAvgTime = spans => spans.reduce((a, b) => a + b.duration, 0) / spans.length;
 
-function computeStdDeviation(spans, avgTime) {
+const computeStdDeviation = (spans, avgTime) => {
   const sum = spans
     .map(span => (span.duration - avgTime) ** 2)
     .reduce((a, b) => a + b, 0);
   return Math.sqrt(sum / spans.length);
-}
+};
 
 /**
  * Produces the data required for populating commit charts.
@@ -178,30 +176,23 @@ function computeStdDeviation(spans, avgTime) {
  *
  * @return {Object[]} the data required to populate the commit charts.
  */
-function getChartData(queries, querySpans, executions, selectedScale) {
-  return queries.map((query) => {
-    const targetQuerySpans = querySpans.filter(querySpan => querySpan.value === query);
-    const times = executions.map((execution) => {
-      const executionQuerySpans = targetQuerySpans.filter(
-        targetQuerySpan => targetQuerySpan.executionId === execution.id && targetQuerySpan.scale === selectedScale,
-      );
-      const avgTime = computeAvgTime(executionQuerySpans);
-      const stdDeviation = computeStdDeviation(executionQuerySpans, avgTime);
+export const getChartData = (queries, querySpans, executions, selectedScale) => queries.map((query) => {
+  const targetQuerySpans = querySpans.filter(querySpan => querySpan.value === query);
+  const times = executions.map((execution) => {
+    const executionQuerySpans = targetQuerySpans.filter(
+      targetQuerySpan => targetQuerySpan.executionId === execution.id && targetQuerySpan.scale === selectedScale,
+    );
+    const avgTime = computeAvgTime(executionQuerySpans);
+    const stdDeviation = computeStdDeviation(executionQuerySpans, avgTime);
 
-      return {
-        commit: execution.commit,
-        executionId: execution.id,
-        avgTime: avgTime / 1000,
-        stdDeviation: stdDeviation / 1000,
-        repetitions: executionQuerySpans.length,
-      };
-    });
-
-    return { query, times };
+    return {
+      commit: execution.commit,
+      executionId: execution.id,
+      avgTime: avgTime / 1000,
+      stdDeviation: stdDeviation / 1000,
+      repetitions: executionQuerySpans.length,
+    };
   });
-}
 
-export default {
-  getLegendsData,
-  getCommitsChartOptions,
-};
+  return { query, times };
+});

--- a/service/dashboard/src/views/overview/index.vue
+++ b/service/dashboard/src/views/overview/index.vue
@@ -41,11 +41,14 @@ export default {
 
   async created() {
     await this.fetchGraphs();
-    this.graphTypes = [...new Set(this.graphs.map(graph => graph.type))];
+    this.graphTypes = this.getGraphTypes();
   },
 
   methods: {
-    // fetch the last n executions for which, we'd like to populate the charts
+    getGraphTypes() {
+      return [...new Set(this.graphs.map(graph => graph.type))];
+    },
+
     async fetchGraphs() {
       this.completedExecutions = (await BenchmarkClient.getLatestCompletedExecutions(
         this.numberOfCompletedExecutions,


### PR DESCRIPTION
## What is the goal of this PR?
Improves code readability, reusability and organisation among dashboard components.

## What are the changes implemented in this PR?

- uses named exports for utils (turns off `import/prefer-default-export` in `.eslintrc.js`)
- extends `util/math.js` and makes use of its functions across components
- reduces length of the `QueryCard` component by moving  `produceStepsAndGroups` to its util
- general refactoring:
  -  `created()`, typically, contains only function calls
  -  using the term `graphType` consistently
  -  `props` to not have `null` as `default`
  -  use the prefix `filter` consistently among method names
  - ...