### PR TITLE
Change from IP to internal google name

### DIFF
--- a/service/executor/execute.sh
+++ b/service/executor/execute.sh
@@ -62,7 +62,7 @@ unzip profiler.zip
 cd profiler
 
 # --- run zipkin ---
-tmux new-session -d -s zipkin "STORAGE_TYPE=elasticsearch ES_HOSTS=http://$SERVICE_ADDR:9200 ES_INDEX=benchmark java -jar external-dependencies/zipkin.jar"
+tmux new-session -d -s zipkin "STORAGE_TYPE=elasticsearch ES_HOSTS=benchmark-service:9200 ES_INDEX=benchmark java -jar external-dependencies/zipkin.jar"
 
 
 # notify benchmark service about start
@@ -74,17 +74,17 @@ curl --header "Content-Type: application/json" \
     https://$SERVICE_ADDR/execution/start
 
 # -- write queries --
-./benchmark --config ./scenario/road_network/road_config_write.yml --execution-name "$EXECUTION_ID" --elastic-uri $SERVICE_ADDR:9200
-./benchmark --config ./scenario/complex/config_write.yml --execution-name "$EXECUTION_ID" --elastic-uri $SERVICE_ADDR:9200
+./benchmark --config ./scenario/road_network/road_config_write.yml --execution-name "$EXECUTION_ID" --elastic-uri benchmark-service:9200
+./benchmark --config ./scenario/complex/config_write.yml --execution-name "$EXECUTION_ID" --elastic-uri benchmark-service:9200
 
 # -- read queries --
-./benchmark --config ./scenario/road_network/road_config_read.yml                --execution-name "$EXECUTION_ID" --elastic-uri $SERVICE_ADDR:9200 --keyspace road_network_read
-./benchmark --config ./scenario/biochemical_network/biochemical_config_read.yml  --execution-name "$EXECUTION_ID" --elastic-uri $SERVICE_ADDR:9200
-./benchmark --config ./scenario/complex/config_read.yml                          --execution-name "$EXECUTION_ID" --elastic-uri $SERVICE_ADDR:9200 --keyspace generic_uniform_network_read
-./benchmark --config ./scenario/reasoning/config_read.yml                        --execution-name "$EXECUTION_ID" --elastic-uri $SERVICE_ADDR:9200 --keyspace reasoner --load-schema --static-data-import
-./benchmark --config ./scenario/rule_scaling/config_read.yml                     --execution-name "$EXECUTION_ID" --elastic-uri $SERVICE_ADDR:9200 --keyspace rule_scaling --load-schema --static-data-import
-./benchmark --config ./scenario/schema/data_definition_config.yml                --execution-name "$EXECUTION_ID" --elastic-uri $SERVICE_ADDR:9200 --keyspace schema --load-schema --no-data-generation
-./benchmark --config ./scenario/attribute/attribute_read_config.yml              --execution-name "$EXECUTION_ID" --elastic-uri $SERVICE_ADDR:9200 --keyspace attribute
+./benchmark --config ./scenario/road_network/road_config_read.yml                --execution-name "$EXECUTION_ID" --elastic-uri benchmark-service:9200 --keyspace road_network_read
+./benchmark --config ./scenario/biochemical_network/biochemical_config_read.yml  --execution-name "$EXECUTION_ID" --elastic-uri benchmark-service:9200
+./benchmark --config ./scenario/complex/config_read.yml                          --execution-name "$EXECUTION_ID" --elastic-uri benchmark-service:9200 --keyspace generic_uniform_network_read
+./benchmark --config ./scenario/reasoning/config_read.yml                        --execution-name "$EXECUTION_ID" --elastic-uri benchmark-service:9200 --keyspace reasoner --load-schema --static-data-import
+./benchmark --config ./scenario/rule_scaling/config_read.yml                     --execution-name "$EXECUTION_ID" --elastic-uri benchmark-service:9200 --keyspace rule_scaling --load-schema --static-data-import
+./benchmark --config ./scenario/schema/data_definition_config.yml                --execution-name "$EXECUTION_ID" --elastic-uri benchmark-service:9200 --keyspace schema --load-schema --no-data-generation
+./benchmark --config ./scenario/attribute/attribute_read_config.yml              --execution-name "$EXECUTION_ID" --elastic-uri benchmark-service:9200 --keyspace attribute
 
 # TODO report log files
 


### PR DESCRIPTION
## What is the goal of this PR?
Benchmark executions fail when they cannot reach the elasticsearch instance. Using `benchmark.grakn.ai` instead of the explicit external google-managed IP fails for unknown reasons, even when elastic is configured to listen to all network hosts. The workaround for this is to use the internal google VM name (`benchmark-service`) that we do not expect to have change instead of the IP or the URL.
Google internal converts this into an internal URI. This can be also be combined with more strict network host settings in elastic to only allow datacenter-local access to the server.


## What are the changes implemented in this PR?
* Replace direct accesses to the elastic IP with `benchmark-service` for all cases that are not calling the web server endpoints (those are separate HTTPS calls)