### PR TITLE
Rectify Execution and VM controllers

### DIFF
--- a/service/web-server/src/controllers/execution/index.ts
+++ b/service/web-server/src/controllers/execution/index.ts
@@ -25,8 +25,7 @@ export interface IExecutionController {
     updateStatusInternal: (execution: IExecution, status: TStatus) => Promise<void>;
 }
 
-// tslint:disable-next-line: function-name
-export function ExecutionController(this: IExecutionController, client: IEsClient) {
+export function ExecutionController(client: IEsClient) {
     this.esClient = client;
 
     this.create = create.bind(this);
@@ -36,7 +35,7 @@ export function ExecutionController(this: IExecutionController, client: IEsClien
     this.updateStatusInternal = updateStatusInternal.bind(this);
 }
 
-async function create(this: IExecutionController, req, res) {
+async function create(req, res) {
     const { commit, repoUrl } = req.body;
     const execution: IExecution = {
         commit,
@@ -71,7 +70,7 @@ async function create(this: IExecutionController, req, res) {
     }
 }
 
-async function updateStatus(this: IExecutionController, req, res, status: TStatus) {
+async function updateStatus(req, res, status: TStatus) {
     const execution = req.body;
 
     try {
@@ -86,7 +85,7 @@ async function updateStatus(this: IExecutionController, req, res, status: TStatu
 // since updating the status of an execution needs to be done both internally (in the process of running the benchmark)
 // and externally (via the dashboard), we need this method which is called directly for internal use, and through
 // its wrapper for external use
-async function updateStatusInternal(this: IExecutionController, execution: IExecution, status: TStatus): Promise<void> {
+async function updateStatusInternal(execution: IExecution, status: TStatus): Promise<void> {
     const payload: RequestParams.Update<{ doc: Partial<IExecution> }> = {
         ...ES_PAYLOAD_COMMON, id: execution.id, body: { doc: { status } },
     };
@@ -98,15 +97,15 @@ async function updateStatusInternal(this: IExecutionController, execution: IExec
     console.log(`Execution ${execution.id} marked as ${status}.`);
 
     const vmDeletionStatuses: TStatuses = ['COMPLETED', 'FAILED', 'CANCELLED'];
-
     if (vmDeletionStatuses.includes(status)) {
         const vm: IVMController = new VMController(execution);
-        await vm.downloadLogs().catch((error) => { throw error; });
-        vm.terminate().catch((error) => { console.log(error); });
+        vm.downloadLogs()
+            .then(() => { vm.terminate().catch((error) => { console.log(error); }); })
+            .catch((error) => { throw error; });
     }
 }
 
-async function destroy(this: IExecutionController, req, res) {
+async function destroy(req, res) {
     try {
         const execution: IExecution = req.body;
         const id = execution.id;
@@ -120,12 +119,12 @@ async function destroy(this: IExecutionController, req, res) {
 
         res.status(200).json({});
     } catch (error) {
-        res.status(500).json({});
         console.error(error);
+        res.status(500).json({});
     }
 }
 
-function getGraphqlServer(this: IExecutionController) {
+function getGraphqlServer() {
     return graphqlHTTP({
         schema,
         context: { client: this.esClient },

--- a/service/web-server/src/controllers/vm/index.ts
+++ b/service/web-server/src/controllers/vm/index.ts
@@ -5,8 +5,7 @@ import { config } from '../../config';
 
 export interface IVMController {
     execution: IExecution;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    computeClient: any;
+    computeClient;
     zone: 'us-east1-b';
     project: 'grakn-dev';
     machineType: 'n1-standard-16';
@@ -16,7 +15,6 @@ export interface IVMController {
     webUri: string;
     logDir: string;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     start: () => Promise<void>;
     execute: () => Promise<void>;
     terminate: () => Promise<void>;

--- a/service/web-server/src/controllers/vm/index.ts
+++ b/service/web-server/src/controllers/vm/index.ts
@@ -17,14 +17,13 @@ export interface IVMController {
     logDir: string;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    start: () => Promise<any>;
+    start: () => Promise<void>;
     execute: () => Promise<void>;
     terminate: () => Promise<void>;
     downloadLogs: () => Promise<void>;
 }
 
-// tslint:disable-next-line: function-name
-export function VMController(this: IVMController, execution: IExecution) {
+export function VMController(execution: IExecution) {
     this.execution = execution;
     this.computeClient = new ComputeClient();
     this.zone = 'us-east1-b';
@@ -41,7 +40,7 @@ export function VMController(this: IVMController, execution: IExecution) {
     this.downloadLogs = downloadLogs.bind(this);
 }
 
-async function start(this: IVMController) {
+async function start() {
     const { vmName } = this.execution;
 
     const config = {
@@ -73,7 +72,7 @@ async function start(this: IVMController) {
     console.log(`${vmName} VM instance is up and running.`);
 }
 
-async function execute(this: IVMController) {
+async function execute() {
     const { vmName, commit, repoUrl, id } = this.execution;
     const bashFile = `${__dirname}/scripts/runExecute.sh`;
     const executeFile = `${config.appRoot}/resources/execute.sh`;
@@ -86,7 +85,7 @@ async function execute(this: IVMController) {
     ).catch((error) => { throw error; });
 }
 
-async function terminate(this: IVMController) {
+async function terminate() {
     const vmName: string = this.execution.vmName;
 
     console.log(`Terminating ${vmName} VM instance.`);
@@ -104,7 +103,7 @@ async function terminate(this: IVMController) {
     });
 }
 
-async function downloadLogs(this: IVMController) {
+async function downloadLogs() {
     const { vmName } = this.execution;
     const bashFile = `${__dirname}/scripts/downloadLogs.sh`;
 


### PR DESCRIPTION
## What is the goal of this PR?

The make the code for `ExecutionController` and `VMController` consistent with the implementation of the `SpanController`.

## What are the changes implemented in this PR?
Apart from minor improvements, this PR also contains a bugfix. Within `ExecutionController.updateStatusInternal`, await is no longer used for `downloadLogs`, so that this task takes place in the background allowing `updateStatus`, where `updateStatusInternal` may be invoked from, to respond as soon as the status of the execution has been updated.
