### PR TITLE
Query Generator v1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,11 @@ jobs:
           command: bazel test //common/analysis/test:insert-query-analysis-unit-test --test_output=errors
       - run-bazel-rbe:
           command: bazel test //common/configuration/test:configuration-test --test_output=errors
+      # run integration tests that do not depend on external grakn
+      - run-bazel-rbe:
+          command: bazel test //querygen/test-integration:query-generator-it --test_output=errors
+      - run-bazel-rbe:
+          command: bazel test //querygen/test-integration:schema-walker-it --test_output=errors
       # run integration tests
       - run-bazel-rbe:
           command: bazel build @graknlabs_grakn_core//:assemble-linux-targz

--- a/profiler/test-integration/DataImportIT.java
+++ b/profiler/test-integration/DataImportIT.java
@@ -1,3 +1,21 @@
+/*
+ *  GRAKN.AI - THE KNOWLEDGE GRAPH
+ *  Copyright (C) 2019 Grakn Labs Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package grakn.benchmark.profiler;
 
 import grakn.benchmark.common.configuration.parse.BenchmarkArguments;

--- a/querygen/BUILD
+++ b/querygen/BUILD
@@ -1,0 +1,21 @@
+#
+#  GRAKN.AI - THE KNOWLEDGE GRAPH
+#  Copyright (C) 2019 Grakn Labs Ltd
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as
+#  published by the Free Software Foundation, either version 3 of the
+#  License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+load("@graknlabs_bazel_distribution//common:rules.bzl", "java_deps")
+
+

--- a/querygen/SchemaWalker.java
+++ b/querygen/SchemaWalker.java
@@ -1,0 +1,22 @@
+package grakn.benchmark.querygen;
+
+import grakn.core.concept.type.Type;
+
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+class SchemaWalker {
+
+    /**
+     * Implementation may vary - either a true random walk implemented using sub!, or a random picking of the subtype
+     * @param rootType starting type
+     * @return some type that is a subtype of rootType
+     */
+    public static Type walkSub(Type rootType, Random random) {
+        List<Type> subs = rootType.subs().collect(Collectors.toList());
+        int index = random.nextInt(subs.size());
+        return subs.get(index);
+    }
+
+}

--- a/querygen/src/BUILD
+++ b/querygen/src/BUILD
@@ -16,23 +16,22 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-java_test(
-    name = "query-generator-it",
-    test_class = "grakn.benchmark.querygen.QueryGeneratorIT",
-    srcs = ["QueryGeneratorIT.java"],
+java_library(
+    name = "query-generator",
+    srcs = glob(["*.java"]),
     deps = [
-        "//querygen/src:query-generator",
         "@graknlabs_client_java//:client-java",
-        "@graknlabs_grakn_core//concept:concept",
         "@graknlabs_graql//java:graql",
-        "@graknlabs_grakn_core//test-integration/rule:grakn-test-server"
+        "@graknlabs_grakn_core//api:api",
+        "@graknlabs_grakn_core//concept:concept",
+
+        # together these can be used to create clients with tracing enabled
+        "//dependencies/maven/artifacts/org/slf4j:slf4j-api",
+#        "//dependencies/maven/artifacts/commons-cli",
     ],
-    classpath_resources = [
-        "//querygen/test-integration/resources:logback-test"
+    runtime_deps = [
+        "//dependencies/maven/artifacts/io/grpc:grpc-netty-shaded",
+        "//dependencies/maven/artifacts/ch/qos/logback:logback-classic",
     ],
-    data = [
-        "//querygen/test-integration/conf:cassandra-embedded.yaml",
-        "//querygen/test-integration/conf:grakn.properties",
-        "//querygen/test-integration/resources:schema.gql"
-    ]
+    visibility = ["//visibility:public"]
 )

--- a/querygen/src/Pair.java
+++ b/querygen/src/Pair.java
@@ -1,0 +1,21 @@
+package grakn.benchmark.querygen;
+
+public class Pair<S,T> {
+
+    private S first;
+    private T second;
+
+    public Pair(S first, T second) {
+        this.first = first;
+        this.second = second;
+    }
+
+    public S getFirst() {
+        return first;
+    }
+
+    public T getSecond() {
+        return second;
+    }
+
+}

--- a/querygen/src/Pair.java
+++ b/querygen/src/Pair.java
@@ -1,5 +1,7 @@
 package grakn.benchmark.querygen;
 
+import java.util.Objects;
+
 public class Pair<S,T> {
 
     private S first;
@@ -17,5 +19,29 @@ public class Pair<S,T> {
     public T getSecond() {
         return second;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (o instanceof Pair) {
+            Pair that = (Pair) o;
+            return Objects.equals(this.first, that.first) &&
+                    Objects.equals(this.second, that.second);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        int h = 1;
+        h *= 1000003;
+        h ^= (first == null) ? 0 : first.hashCode();
+        h *= 1000003;
+        h ^= (second == null) ? 0 : second.hashCode();
+        return h;
+    }
+
 
 }

--- a/querygen/src/QueryBuilder.java
+++ b/querygen/src/QueryBuilder.java
@@ -3,7 +3,9 @@ package grakn.benchmark.querygen;
 import grakn.core.concept.type.Type;
 import graql.lang.statement.Variable;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -20,6 +22,7 @@ public class QueryBuilder {
 
     public QueryBuilder() {
         this.variableTypeMap = new HashMap<>();
+        this.unvisitedVariables = new ArrayList<>();
     }
 
     public Variable reserveNewVariable() {

--- a/querygen/src/QueryBuilder.java
+++ b/querygen/src/QueryBuilder.java
@@ -6,7 +6,6 @@ import grakn.core.concept.type.Type;
 import graql.lang.Graql;
 import graql.lang.pattern.Pattern;
 import graql.lang.query.GraqlGet;
-import graql.lang.statement.Statement;
 import graql.lang.statement.StatementInstance;
 import graql.lang.statement.Variable;
 
@@ -19,12 +18,11 @@ import java.util.stream.Collectors;
 
 public class QueryBuilder {
 
-    Map<Variable, Type> variableTypeMap;
+    final Map<Variable, Type> variableTypeMap;
+    final Map<Variable, List<Variable>> attributeOwnership;
+    final Map<Variable, List<Pair<Variable, Role>>> relationRolePlayers;
 
-    Map<Variable, List<Variable>> attributeOwnership;
-    Map<Variable, List<Pair<Variable, Role>>> relationRolePlayers;
-
-    List<Variable> unvisitedVariables;
+    final List<Variable> unvisitedVariables;
 
     int nextVar = 0;
 

--- a/querygen/src/QueryBuilder.java
+++ b/querygen/src/QueryBuilder.java
@@ -105,7 +105,11 @@ public class QueryBuilder {
                 }
             }
 
-            // TODO relation role players
+            if (relationRolePlayers.containsKey(statementVariable)) {
+                for (Pair<Variable, Role> rolePlayer : relationRolePlayers.get(statementVariable)) {
+                    pattern = pattern.rel(rolePlayer.getSecond().label().toString(), Graql.var(rolePlayer.getFirst()));
+                }
+            }
 
             patterns.add(pattern);
 

--- a/querygen/src/QueryBuilder.java
+++ b/querygen/src/QueryBuilder.java
@@ -22,6 +22,7 @@ public class QueryBuilder {
 
     QueryBuilder() {
         this.variableTypeMap = new HashMap<>();
+        this.attributeOwnership = new HashMap<>();
         this.unvisitedVariables = new ArrayList<>();
     }
 
@@ -31,13 +32,18 @@ public class QueryBuilder {
         return var;
     }
 
-    boolean containsVariableWithType(Type type) {
-        return variableTypeMap.values().contains(type);
-    }
 
     public void addMapping(Variable var, Type type) {
         variableTypeMap.put(var, type);
         unvisitedVariables.add(var);
+    }
+
+    public void addOwnership(Variable owner, Variable owned) {
+        attributeOwnership.put(owner, owned);
+    }
+
+    boolean containsVariableWithType(Type type) {
+        return variableTypeMap.values().contains(type);
     }
 
     public Type getType(Variable var) {

--- a/querygen/src/QueryBuilder.java
+++ b/querygen/src/QueryBuilder.java
@@ -1,6 +1,7 @@
 package grakn.benchmark.querygen;
 
 import grakn.client.GraknClient;
+import grakn.core.concept.type.Role;
 import grakn.core.concept.type.Type;
 import graql.lang.Graql;
 import graql.lang.pattern.Pattern;
@@ -21,6 +22,7 @@ public class QueryBuilder {
     Map<Variable, Type> variableTypeMap;
 
     Map<Variable, List<Variable>> attributeOwnership;
+    Map<Variable, List<Pair<Variable, Role>>> relationRolePlayers;
 
     List<Variable> unvisitedVariables;
 
@@ -29,6 +31,7 @@ public class QueryBuilder {
     QueryBuilder() {
         this.variableTypeMap = new HashMap<>();
         this.attributeOwnership = new HashMap<>();
+        this.relationRolePlayers = new HashMap<>();
         this.unvisitedVariables = new ArrayList<>();
     }
 
@@ -39,14 +42,19 @@ public class QueryBuilder {
     }
 
 
-    public void addMapping(Variable var, Type type) {
+    void addMapping(Variable var, Type type) {
         variableTypeMap.put(var, type);
         unvisitedVariables.add(var);
     }
 
-    public void addOwnership(Variable owner, Variable owned) {
+    void addOwnership(Variable owner, Variable owned) {
         attributeOwnership.putIfAbsent(owner, new ArrayList<>());
         attributeOwnership.get(owner).add(owned);
+    }
+
+    void addRolePlayer(Variable relationVar, Variable rolePlayerVariable, Role role) {
+        relationRolePlayers.putIfAbsent(relationVar, new ArrayList<>());
+        relationRolePlayers.get(relationVar).add(new Pair<>(rolePlayerVariable, role));
     }
 
     boolean containsVariableWithType(Type type) {
@@ -104,4 +112,6 @@ public class QueryBuilder {
         }
         return Graql.match(patterns).get();
     }
+
+
 }

--- a/querygen/src/QueryBuilder.java
+++ b/querygen/src/QueryBuilder.java
@@ -5,10 +5,10 @@ import graql.lang.statement.Variable;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 public class QueryBuilder {
 
@@ -20,15 +20,19 @@ public class QueryBuilder {
 
     int nextVar = 0;
 
-    public QueryBuilder() {
+    QueryBuilder() {
         this.variableTypeMap = new HashMap<>();
         this.unvisitedVariables = new ArrayList<>();
     }
 
-    public Variable reserveNewVariable() {
+    Variable reserveNewVariable() {
         Variable var = new Variable("v" + nextVar);
         nextVar++;
         return var;
+    }
+
+    boolean containsVariableWithType(Type type) {
+        return variableTypeMap.values().contains(type);
     }
 
     public void addMapping(Variable var, Type type) {
@@ -40,14 +44,24 @@ public class QueryBuilder {
         return variableTypeMap.get(var);
     }
 
-    public Variable randomUnvisitedVariable(Random random) {
+    boolean haveUnvisitedVariable() {
+        return !unvisitedVariables.isEmpty();
+    }
+
+    Variable randomUnvisitedVariable(Random random) {
         int index = random.nextInt(unvisitedVariables.size());
         return unvisitedVariables.get(index);
     }
 
-    public void visitVariable(Variable var) {
+    void visitVariable(Variable var) {
         unvisitedVariables.remove(var);
     }
 
 
+    List<Variable> variablesWithType(Type type) {
+        return variableTypeMap.entrySet().stream()
+                .filter(entry -> entry.getValue().equals(type))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+    }
 }

--- a/querygen/src/QueryBuilder.java
+++ b/querygen/src/QueryBuilder.java
@@ -1,0 +1,50 @@
+package grakn.benchmark.querygen;
+
+import grakn.core.concept.type.Type;
+import graql.lang.statement.Variable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+public class QueryBuilder {
+
+    Map<Variable, Type> variableTypeMap;
+
+    Map<Variable, Variable> attributeOwnership;
+
+    List<Variable> unvisitedVariables;
+
+    int nextVar = 0;
+
+    public QueryBuilder() {
+        this.variableTypeMap = new HashMap<>();
+    }
+
+    public Variable reserveNewVariable() {
+        Variable var = new Variable("v" + nextVar);
+        nextVar++;
+        return var;
+    }
+
+    public void addMapping(Variable var, Type type) {
+        variableTypeMap.put(var, type);
+        unvisitedVariables.add(var);
+    }
+
+    public Type getType(Variable var) {
+        return variableTypeMap.get(var);
+    }
+
+    public Variable randomUnvisitedVariable(Random random) {
+        int index = random.nextInt(unvisitedVariables.size());
+        return unvisitedVariables.get(index);
+    }
+
+    public void visitVariable(Variable var) {
+        unvisitedVariables.remove(var);
+    }
+
+
+}

--- a/querygen/src/QueryGenerator.java
+++ b/querygen/src/QueryGenerator.java
@@ -49,7 +49,7 @@ public class QueryGenerator {
         for (int i = 0; i < numQueries; i++) {
             try (GraknClient.Transaction tx = session.transaction().write()) {
                 QueryBuilder builder = generateNewQuery(tx);
-                queries.add(builder.build(tx));
+                queries.add(builder.build(tx, random));
             }
         }
 

--- a/querygen/src/QueryGenerator.java
+++ b/querygen/src/QueryGenerator.java
@@ -21,6 +21,7 @@ package grakn.benchmark.querygen;
 import grakn.client.GraknClient;
 import grakn.core.concept.type.AttributeType;
 import grakn.core.concept.type.Type;
+import graql.lang.query.GraqlGet;
 import graql.lang.statement.Variable;
 
 import java.util.ArrayList;
@@ -40,14 +41,15 @@ public class QueryGenerator {
         this.random = new Random(0);
     }
 
-    List<String> generate(int numQueries) {
-        List<String> queries = new ArrayList<>(numQueries);
+    List<GraqlGet> generate(int numQueries) {
+        List<GraqlGet> queries = new ArrayList<>(numQueries);
         GraknClient client = new GraknClient(graknUri);
         GraknClient.Session session = client.session(keyspace);
 
         for (int i = 0; i < numQueries; i++) {
             try (GraknClient.Transaction tx = session.transaction().write()) {
-                queries.add(generateNewQuery(tx).toString());
+                QueryBuilder builder = generateNewQuery(tx);
+                queries.add(builder.build(tx));
             }
         }
 
@@ -86,8 +88,6 @@ public class QueryGenerator {
         }
 
         // TODO add a comparison between compatible attributes with a low probability
-
-        // convert QueryBuilder into graql query
 
         return builder;
     }

--- a/querygen/src/QueryGenerator.java
+++ b/querygen/src/QueryGenerator.java
@@ -80,7 +80,7 @@ public class QueryGenerator {
             }
 
             // assign attribute ownership
-            assignAttributesForVarType(tx, varType, builder);
+            assignAttributes(tx, var, varType, builder);
 
             variablesProduced++;
         }
@@ -92,7 +92,7 @@ public class QueryGenerator {
         return builder;
     }
 
-    private void assignAttributesForVarType(GraknClient.Transaction tx, Type varType, QueryBuilder builder) {
+    private void assignAttributes(GraknClient.Transaction tx, Variable var, Type varType, QueryBuilder builder) {
         // TODO determine how many attributes should be had
         int maxAttrs = 3;
         int attrs = random.nextInt(maxAttrs);
@@ -110,6 +110,7 @@ public class QueryGenerator {
 
                 // write this new mapping to the query builder
                 builder.addMapping(attributeVariable, attributeType);
+                builder.addOwnership(var, attributeVariable);
             }
         }
     }

--- a/querygen/src/QueryGenerator.java
+++ b/querygen/src/QueryGenerator.java
@@ -47,14 +47,15 @@ public class QueryGenerator {
         GraknClient.Session session = client.session(keyspace);
 
         for (int i = 0; i < numQueries; i++) {
-            queries.add(generateNewQuery(session).toString());
+            try (GraknClient.Transaction tx = session.transaction().write()) {
+                queries.add(generateNewQuery(tx).toString());
+            }
         }
 
         return queries;
     }
 
-    private QueryBuilder generateNewQuery(GraknClient.Session session) {
-        GraknClient.Transaction tx = session.transaction().write();
+    QueryBuilder generateNewQuery(GraknClient.Transaction tx) {
         Type rootThing = tx.getMetaConcept();
 
         QueryBuilder builder = new QueryBuilder();
@@ -65,25 +66,25 @@ public class QueryGenerator {
 
         // TODO determine how long this query should be
 
-        for (int i = 0; i < 5; i++) {
-            // pick a new variable from the mapping we have not visited
-            Variable var = builder.randomUnvisitedVariable(random);
-            builder.visitVariable(var);
-            Type varType = builder.getType(var);
-
-            if (varType.isRelationType()) {
-                // assign role players
-            }
-
-            // assign attribute ownership
-            assignAttributes(var, varType, builder);
-        }
+//        for (int i = 0; i < 5; i++) {
+//            // pick a new variable from the mapping we have not visited
+//            Variable var = builder.randomUnvisitedVariable(random);
+//            builder.visitVariable(var);
+//            Type varType = builder.getType(var);
+//
+//            if (varType.isRelationType()) {
+//                // assign role players
+//            }
+//
+//            // assign attribute ownership
+//            assignAttributes(var, varType, builder);
+//        }
 
         // TODO add a comparison between compatible attributes with a low probability
 
         // convert QueryBuilder into graql query
 
-        return null;
+        return builder;
     }
 
     private void assignAttributes(Variable var, Type varType, QueryBuilder builder) {

--- a/querygen/src/QueryGenerator.java
+++ b/querygen/src/QueryGenerator.java
@@ -51,13 +51,15 @@ public class QueryGenerator {
 
     List<GraqlGet> generate(int numQueries) {
         List<GraqlGet> queries = new ArrayList<>(numQueries);
-        GraknClient client = new GraknClient(graknUri);
-        GraknClient.Session session = client.session(keyspace);
+        try (GraknClient client = new GraknClient(graknUri);
+             GraknClient.Session session = client.session(keyspace);) {
 
-        for (int i = 0; i < numQueries; i++) {
-            try (GraknClient.Transaction tx = session.transaction().write()) {
-                QueryBuilder builder = generateNewQuery(tx);
-                queries.add(builder.build(tx, random));
+
+            for (int i = 0; i < numQueries; i++) {
+                try (GraknClient.Transaction tx = session.transaction().write()) {
+                    QueryBuilder builder = generateNewQuery(tx);
+                    queries.add(builder.build(tx, random));
+                }
             }
         }
 

--- a/querygen/src/QueryGenerator.java
+++ b/querygen/src/QueryGenerator.java
@@ -40,26 +40,19 @@ public class QueryGenerator {
     private static final Logger LOG = LoggerFactory.getLogger(QueryGenerator.class);
 
     private final Random random;
-    private String graknUri;
-    private String keyspace;
+    private final GraknClient.Session session;
 
-    public QueryGenerator(String graknUri, String keyspace) {
-        this.graknUri = graknUri;
-        this.keyspace = keyspace;
+    public QueryGenerator(GraknClient.Session session) {
+        this.session = session;
         this.random = new Random(0);
     }
 
     List<GraqlGet> generate(int numQueries) {
         List<GraqlGet> queries = new ArrayList<>(numQueries);
-        try (GraknClient client = new GraknClient(graknUri);
-             GraknClient.Session session = client.session(keyspace);) {
-
-
-            for (int i = 0; i < numQueries; i++) {
-                try (GraknClient.Transaction tx = session.transaction().write()) {
-                    QueryBuilder builder = generateNewQuery(tx);
-                    queries.add(builder.build(tx, random));
-                }
+        for (int i = 0; i < numQueries; i++) {
+            try (GraknClient.Transaction tx = session.transaction().write()) {
+                QueryBuilder builder = generateNewQuery(tx);
+                queries.add(builder.build(tx, random));
             }
         }
 

--- a/querygen/src/QueryGenerator.java
+++ b/querygen/src/QueryGenerator.java
@@ -1,0 +1,52 @@
+/*
+ *  GRAKN.AI - THE KNOWLEDGE GRAPH
+ *  Copyright (C) 2019 Grakn Labs Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package grakn.benchmark.querygen;
+
+import grakn.client.GraknClient;
+import graql.lang.query.GraqlGet;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class QueryGenerator {
+
+    private String graknUri;
+    private String keyspace;
+
+    public QueryGenerator(String graknUri, String keyspace) {
+        this.graknUri = graknUri;
+        this.keyspace = keyspace;
+    }
+
+    List<GraqlGet> generate(int numQueries) {
+        List<GraqlGet> queries = new ArrayList<>(numQueries);
+        GraknClient client = new GraknClient(graknUri);
+        GraknClient.Session session = client.session(keyspace);
+
+        for (int i = 0; i < numQueries; i++) {
+            queries.add(generateNewQuery(session));
+        }
+
+        return queries;
+    }
+
+    private GraqlGet generateNewQuery(GraknClient.Session session) {
+        return null;
+    }
+}

--- a/querygen/src/QueryGenerator.java
+++ b/querygen/src/QueryGenerator.java
@@ -19,34 +19,84 @@
 package grakn.benchmark.querygen;
 
 import grakn.client.GraknClient;
+import grakn.core.concept.type.AttributeType;
+import grakn.core.concept.type.Type;
 import graql.lang.query.GraqlGet;
+import graql.lang.statement.Variable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
 
 public class QueryGenerator {
 
+    private final Random random;
     private String graknUri;
     private String keyspace;
 
     public QueryGenerator(String graknUri, String keyspace) {
         this.graknUri = graknUri;
         this.keyspace = keyspace;
+        this.random = new Random(0);
     }
 
-    List<GraqlGet> generate(int numQueries) {
-        List<GraqlGet> queries = new ArrayList<>(numQueries);
+    List<String> generate(int numQueries) {
+        List<String> queries = new ArrayList<>(numQueries);
         GraknClient client = new GraknClient(graknUri);
         GraknClient.Session session = client.session(keyspace);
 
         for (int i = 0; i < numQueries; i++) {
-            queries.add(generateNewQuery(session));
+            queries.add(generateNewQuery(session).toString());
         }
 
         return queries;
     }
 
-    private GraqlGet generateNewQuery(GraknClient.Session session) {
+    private QueryBuilder generateNewQuery(GraknClient.Session session) {
+        GraknClient.Transaction tx = session.transaction().write();
+        Type rootThing = tx.getMetaConcept();
+
+        QueryBuilder builder = new QueryBuilder();
+
+        Type startingType = SchemaWalker.walkSub(rootThing, random);
+        Variable startingVariable = builder.reserveNewVariable();
+        builder.addMapping(startingVariable, startingType);
+
+        // TODO determine how long this query should be
+
+        for (int i = 0; i < 5; i++) {
+            // pick a new variable from the mapping we have not visited
+            Variable var = builder.randomUnvisitedVariable(random);
+            builder.visitVariable(var);
+            Type varType = builder.getType(var);
+
+            if (varType.isRelationType()) {
+                // assign role players
+            }
+
+            // assign attribute ownership
+            assignAttributes(var, varType, builder);
+        }
+
+        // TODO add a comparison between compatible attributes with a low probability
+
+        // convert QueryBuilder into graql query
+
         return null;
     }
+
+    private void assignAttributes(Variable var, Type varType, QueryBuilder builder) {
+        // TODO determine how many attributes should be had
+        int maxAttrs = 3;
+        int attrs = random.nextInt(maxAttrs);
+
+        List<AttributeType> allowedAttributes = varType.attributes().collect(Collectors.toList());
+        for (int i = 0; i < attrs; i++) {
+            AttributeType attrToOwn = allowedAttributes.get(random.nextInt(allowedAttributes.size()));
+            // choose between reusing a variable for this type
+            // and a new variable
+        }
+    }
+
 }

--- a/querygen/src/SchemaWalker.java
+++ b/querygen/src/SchemaWalker.java
@@ -1,7 +1,11 @@
 package grakn.benchmark.querygen;
 
+import grakn.client.GraknClient;
+import grakn.core.concept.type.AttributeType;
+import grakn.core.concept.type.SchemaConcept;
 import grakn.core.concept.type.Type;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -10,13 +14,28 @@ class SchemaWalker {
 
     /**
      * Implementation may vary - either a true random walk implemented using sub!, or a random picking of the subtype
+     *
      * @param rootType starting type
      * @return some type that is a subtype of rootType
      */
-    static Type walkSub(Type rootType, Random random) {
+    static Type walkSubs(Type rootType, Random random) {
         List<Type> subs = rootType.subs().collect(Collectors.toList());
         int index = random.nextInt(subs.size());
         return subs.get(index);
     }
 
+    static Type walkSupsNoMeta(GraknClient.Transaction tx, Type ownableAttribute, Random random) {
+        List<Type> metaConcepts = Arrays.asList(
+                tx.getMetaConcept(),
+                tx.getMetaEntityType(),
+                tx.getMetaRelationType(),
+                tx.getMetaAttributeType()
+                // not including Role and Rule as they are not Type but SchemaConcept
+        );
+
+        List<? extends Type> nonMetaSups = ownableAttribute.sups().filter(type -> !metaConcepts.contains(type)).collect(Collectors.toList());
+
+        int index = random.nextInt(nonMetaSups.size());
+        return nonMetaSups.get(index);
+    }
 }

--- a/querygen/src/SchemaWalker.java
+++ b/querygen/src/SchemaWalker.java
@@ -13,7 +13,7 @@ class SchemaWalker {
      * @param rootType starting type
      * @return some type that is a subtype of rootType
      */
-    public static Type walkSub(Type rootType, Random random) {
+    static Type walkSub(Type rootType, Random random) {
         List<Type> subs = rootType.subs().collect(Collectors.toList());
         int index = random.nextInt(subs.size());
         return subs.get(index);

--- a/querygen/src/SchemaWalker.java
+++ b/querygen/src/SchemaWalker.java
@@ -1,8 +1,6 @@
 package grakn.benchmark.querygen;
 
 import grakn.client.GraknClient;
-import grakn.core.concept.type.AttributeType;
-import grakn.core.concept.type.SchemaConcept;
 import grakn.core.concept.type.Type;
 
 import java.util.Arrays;

--- a/querygen/src/SchemaWalker.java
+++ b/querygen/src/SchemaWalker.java
@@ -23,15 +23,8 @@ class SchemaWalker {
     }
 
     static Type walkSupsNoMeta(GraknClient.Transaction tx, Type ownableAttribute, Random random) {
-        List<Type> metaConcepts = Arrays.asList(
-                tx.getMetaConcept(),
-                tx.getMetaEntityType(),
-                tx.getMetaRelationType(),
-                tx.getMetaAttributeType()
-                // not including Role and Rule as they are not Type but SchemaConcept
-        );
-
-        List<? extends Type> nonMetaSups = ownableAttribute.sups().filter(type -> !metaConcepts.contains(type)).collect(Collectors.toList());
+        Type metaConcept = tx.getMetaConcept();
+        List<? extends Type> nonMetaSups = ownableAttribute.sups().filter(type -> !type.equals(metaConcept)).collect(Collectors.toList());
 
         int index = random.nextInt(nonMetaSups.size());
         return nonMetaSups.get(index);

--- a/querygen/test-integration/BUILD
+++ b/querygen/test-integration/BUILD
@@ -1,0 +1,35 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2019 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+java_test(
+    name = "query-generator-it",
+    test_class = "grakn.benchmark.querygen.QueryGeneratorIT",
+    srcs = ["QueryGeneratorIT.java"],
+    deps = [
+        "@graknlabs_client_java//:client-java",
+        "@graknlabs_grakn_core//concept:concept",
+        "@graknlabs_graql//java:graql",
+#        "//dependencies/maven/artifacts/commons-cli",
+    ],
+    classpath_resources = [
+        "//querygen/test-integration/resources:logback-test"
+        ],
+#    data = [
+#        "//profiler/test-integration/resources:web-content-config"
+#    ]
+)

--- a/querygen/test-integration/BUILD
+++ b/querygen/test-integration/BUILD
@@ -17,9 +17,31 @@
 #
 
 java_test(
-    name = "query-generator-it",
-    test_class = "grakn.benchmark.querygen.QueryGeneratorIT",
-    srcs = ["QueryGeneratorIT.java"],
+     name = "query-generator-it",
+     test_class = "grakn.benchmark.querygen.QueryGeneratorIT",
+     srcs = ["QueryGeneratorIT.java"],
+     deps = [
+         "//querygen/src:query-generator",
+         "@graknlabs_client_java//:client-java",
+         "@graknlabs_grakn_core//concept:concept",
+         "@graknlabs_graql//java:graql",
+         "@graknlabs_grakn_core//test-integration/rule:grakn-test-server"
+     ],
+     classpath_resources = [
+         "//querygen/test-integration/resources:logback-test"
+     ],
+     data = [
+         "//querygen/test-integration/conf:cassandra-embedded.yaml",
+         "//querygen/test-integration/conf:grakn.properties",
+         "//querygen/test-integration/resources:schema.gql"
+     ]
+ )
+
+
+java_test(
+    name = "schema-walker-it",
+    test_class = "grakn.benchmark.querygen.SchemaWalkerIT",
+    srcs = ["SchemaWalkerIT.java"],
     deps = [
         "//querygen/src:query-generator",
         "@graknlabs_client_java//:client-java",

--- a/querygen/test-integration/QueryGeneratorIT.java
+++ b/querygen/test-integration/QueryGeneratorIT.java
@@ -84,7 +84,6 @@ public class QueryGeneratorIT {
         List<GraqlGet> queries = queryGenerator.generate(queriesToGenerate);
         assertEquals(queries.size(), queriesToGenerate);
         for (GraqlGet query : queries) {
-            System.out.println(query);
             assertNotNull(query);
         }
     }

--- a/querygen/test-integration/QueryGeneratorIT.java
+++ b/querygen/test-integration/QueryGeneratorIT.java
@@ -85,6 +85,7 @@ public class QueryGeneratorIT {
         assertEquals(queries.size(), queriesToGenerate);
         for (GraqlGet query : queries) {
             assertNotNull(query);
+            System.out.println(query);
         }
     }
 

--- a/querygen/test-integration/QueryGeneratorIT.java
+++ b/querygen/test-integration/QueryGeneratorIT.java
@@ -1,0 +1,76 @@
+/*
+ *  GRAKN.AI - THE KNOWLEDGE GRAPH
+ *  Copyright (C) 2019 Grakn Labs Ltd
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package grakn.benchmark.querygen;
+
+import grakn.client.GraknClient;
+import grakn.core.rule.GraknTestServer;
+import graql.lang.Graql;
+import graql.lang.query.GraqlGet;
+import graql.lang.query.GraqlQuery;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class QueryGeneratorIT {
+
+    private static final String testKeyspace = "querygen_test";
+
+    @ClassRule
+    public static final GraknTestServer server = new GraknTestServer(
+            Paths.get("querygen/test-integration/conf/grakn.properties"),
+            Paths.get("querygen/test-integration/conf/cassandra-embedded.yaml")
+    );
+
+    @BeforeClass
+    public static void loadSchema() {
+        Path path = Paths.get("querygen");
+        GraknClient client = new GraknClient(server.grpcUri());
+        GraknClient.Session session = client.session(testKeyspace);
+        GraknClient.Transaction transaction = session.transaction().write();
+
+        try {
+            List<String> lines = Files.readAllLines(Paths.get("querygen/test-integration/resources/schema.gql"));
+            String graqlQuery = String.join("\n", lines);
+            transaction.execute((GraqlQuery) Graql.parse(graqlQuery));
+            transaction.commit();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        session.close();
+        client.close();
+    }
+
+    @Test
+    public void queryGeneratorReturnsCorrectNumberOfQueries() {
+        QueryGenerator queryGenerator = new QueryGenerator(server.grpcUri(), testKeyspace);
+        int queriesToGenerate = 100;
+        List<GraqlGet> queries = queryGenerator.generate(queriesToGenerate);
+        assertEquals(queries.size(), queriesToGenerate);
+    }
+
+}

--- a/querygen/test-integration/QueryGeneratorIT.java
+++ b/querygen/test-integration/QueryGeneratorIT.java
@@ -23,6 +23,7 @@ import grakn.core.concept.type.Type;
 import grakn.core.rule.GraknTestServer;
 import graql.lang.Graql;
 import graql.lang.query.GraqlQuery;
+import graql.lang.statement.Variable;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -35,6 +36,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class QueryGeneratorIT {
 
@@ -93,6 +95,28 @@ public class QueryGeneratorIT {
 
             int generatedVars = queryBuilder.nextVar;
             assertEquals(queryBuilder.variableTypeMap.size(), generatedVars);
+        }
+    }
+
+
+    /**
+     * QueryBuilder contains mappings from owner types
+     */
+    @Test
+    public void ownedVariablesAreMappedToAttributeTypes() {
+        QueryGenerator queryGenerator = new QueryGenerator(null, null);
+
+        try (GraknClient client = new GraknClient(server.grpcUri());
+             GraknClient.Session session = client.session(testKeyspace);
+             GraknClient.Transaction tx = session.transaction().write()) {
+
+            // directly generate a new query which contains concepts bound to this tx
+            QueryBuilder queryBuilder = queryGenerator.generateNewQuery(tx);
+
+            for (Variable attributeOwned : queryBuilder.attributeOwnership.values()) {
+                Type attributeOwnedType = queryBuilder.getType(attributeOwned);
+                assertTrue(attributeOwnedType.isAttributeType());
+            }
         }
     }
 

--- a/querygen/test-integration/QueryGeneratorIT.java
+++ b/querygen/test-integration/QueryGeneratorIT.java
@@ -77,9 +77,10 @@ public class QueryGeneratorIT {
 
     /**
      * Test that a single new query is generated as a QueryBuilder
+     * This query builder should have all the reserved vars mapped to a type
      */
     @Test
-    public void newQueryIsReturnedAsBuilderWithValidRootType() {
+    public void newQueryIsReturnedAsBuilderWithAllVarsMapped() {
         // a empty queryGenerator
         QueryGenerator queryGenerator = new QueryGenerator(null, null);
 
@@ -89,12 +90,9 @@ public class QueryGeneratorIT {
 
             // directly generate a new query which contains concepts bound to this tx
             QueryBuilder queryBuilder = queryGenerator.generateNewQuery(tx);
-            assertNotNull(queryBuilder);
 
-            Type rootType = queryBuilder.variableTypeMap.values().iterator().next();
-
-            // this should not throw
-            assertNotNull(tx.getSchemaConcept(rootType.label()));
+            int generatedVars = queryBuilder.nextVar;
+            assertEquals(queryBuilder.variableTypeMap.size(), generatedVars);
         }
     }
 

--- a/querygen/test-integration/QueryGeneratorIT.java
+++ b/querygen/test-integration/QueryGeneratorIT.java
@@ -22,6 +22,7 @@ import grakn.client.GraknClient;
 import grakn.core.concept.type.Type;
 import grakn.core.rule.GraknTestServer;
 import graql.lang.Graql;
+import graql.lang.query.GraqlGet;
 import graql.lang.query.GraqlQuery;
 import graql.lang.statement.Variable;
 import org.junit.BeforeClass;
@@ -32,7 +33,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -72,8 +75,11 @@ public class QueryGeneratorIT {
     public void queryGeneratorReturnsCorrectNumberOfQueries() {
         QueryGenerator queryGenerator = new QueryGenerator(server.grpcUri(), testKeyspace);
         int queriesToGenerate = 100;
-        List<String> queries = queryGenerator.generate(queriesToGenerate);
+        List<GraqlGet> queries = queryGenerator.generate(queriesToGenerate);
         assertEquals(queries.size(), queriesToGenerate);
+        for (GraqlGet query : queries) {
+            assertNotNull(query);
+        }
     }
 
 
@@ -113,7 +119,7 @@ public class QueryGeneratorIT {
             // directly generate a new query which contains concepts bound to this tx
             QueryBuilder queryBuilder = queryGenerator.generateNewQuery(tx);
 
-            for (Variable attributeOwned : queryBuilder.attributeOwnership.values()) {
+            for (Variable attributeOwned : queryBuilder.attributeOwnership.values().stream().flatMap(Collection::stream).collect(Collectors.toSet())) {
                 Type attributeOwnedType = queryBuilder.getType(attributeOwned);
                 assertTrue(attributeOwnedType.isAttributeType());
             }

--- a/querygen/test-integration/QueryGeneratorIT.java
+++ b/querygen/test-integration/QueryGeneratorIT.java
@@ -83,6 +83,7 @@ public class QueryGeneratorIT {
         List<GraqlGet> queries = queryGenerator.generate(queriesToGenerate);
         assertEquals(queries.size(), queriesToGenerate);
         for (GraqlGet query : queries) {
+            System.out.println(query);
             assertNotNull(query);
         }
     }

--- a/querygen/test-integration/SchemaWalkerIT.java
+++ b/querygen/test-integration/SchemaWalkerIT.java
@@ -1,0 +1,70 @@
+package grakn.benchmark.querygen;
+
+import grakn.client.GraknClient;
+import grakn.core.concept.type.Type;
+import grakn.core.rule.GraknTestServer;
+import graql.lang.Graql;
+import graql.lang.query.GraqlQuery;
+import org.hamcrest.CoreMatchers;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class SchemaWalkerIT {
+
+    private static final String testKeyspace = "schemawalker_test";
+
+    @ClassRule
+    public static final GraknTestServer server = new GraknTestServer(
+            Paths.get("querygen/test-integration/conf/grakn.properties"),
+            Paths.get("querygen/test-integration/conf/cassandra-embedded.yaml")
+    );
+
+    @BeforeClass
+    public static void loadSchema() {
+        Path path = Paths.get("querygen");
+        GraknClient client = new GraknClient(server.grpcUri());
+        GraknClient.Session session = client.session(testKeyspace);
+        GraknClient.Transaction transaction = session.transaction().write();
+
+        try {
+            List<String> lines = Files.readAllLines(Paths.get("querygen/test-integration/resources/schema.gql"));
+            String graqlQuery = String.join("\n", lines);
+            transaction.execute((GraqlQuery) Graql.parse(graqlQuery));
+            transaction.commit();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        session.close();
+        client.close();
+    }
+
+    @Test
+    public static void walkSubRetrievesDifferentSubtypes() {
+        GraknClient client = new GraknClient(server.grpcUri());
+        GraknClient.Session session = client.session(testKeyspace);
+        GraknClient.Transaction tx = session.transaction().write();
+
+        Type rootThing = tx.getMetaConcept();
+        Random random = new Random(0);
+
+        List<Type> subTypes = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            subTypes.add(SchemaWalker.walkSub(rootThing, random));
+        }
+
+        assertThat(subTypes, CoreMatchers.everyItem(CoreMatchers.is(rootThing)));
+    }
+}

--- a/querygen/test-integration/conf/BUILD
+++ b/querygen/test-integration/conf/BUILD
@@ -16,23 +16,4 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-java_test(
-    name = "query-generator-it",
-    test_class = "grakn.benchmark.querygen.QueryGeneratorIT",
-    srcs = ["QueryGeneratorIT.java"],
-    deps = [
-        "//querygen/src:query-generator",
-        "@graknlabs_client_java//:client-java",
-        "@graknlabs_grakn_core//concept:concept",
-        "@graknlabs_graql//java:graql",
-        "@graknlabs_grakn_core//test-integration/rule:grakn-test-server"
-    ],
-    classpath_resources = [
-        "//querygen/test-integration/resources:logback-test"
-    ],
-    data = [
-        "//querygen/test-integration/conf:cassandra-embedded.yaml",
-        "//querygen/test-integration/conf:grakn.properties",
-        "//querygen/test-integration/resources:schema.gql"
-    ]
-)
+exports_files(["cassandra-embedded.yaml", "grakn.properties"])

--- a/querygen/test-integration/conf/cassandra-embedded.yaml
+++ b/querygen/test-integration/conf/cassandra-embedded.yaml
@@ -1,0 +1,672 @@
+# Cassandra storage config YAML
+
+# NOTE:
+#   See http://wiki.apache.org/cassandra/StorageConfiguration for
+#   full explanations of configuration directives
+# /NOTE
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
+cluster_name: 'Janus Cassandra Cluster'
+
+# This defines the number of tokens randomly assigned to this node on the ring
+# The more tokens, relative to other nodes, the larger the proportion of data
+# that this node will store. You probably want all nodes to have the same number
+# of tokens assuming they have equal hardware capability.
+#
+# If you leave this unspecified, Cassandra will use the default of 1 token for legacy compatibility,
+# and will use the initial_token as described below.
+#
+# Specifying initial_token will override this setting.
+#
+# If you already have a cluster with 1 token per node, and wish to migrate to
+# multiple tokens per node, see http://wiki.apache.org/cassandra/Operations
+#
+# The default value that ships with Janus is smaller than the default value
+# that ships with Apache Cassandra.  Fewer tokens means faster Faunus run
+# times on small datasets.  That's convenient when testing Janus(-Hadoop) on
+# toy data.  However, increasing num_tokens is strongly recommended for
+# production Janus instances backed by Cassandra.  This low value is just
+# for development and testing.
+#num_tokens: 256
+num_tokens: 4
+
+# initial_token allows you to specify tokens manually.  While you can use # it with
+# vnodes (num_tokens > 1, above) -- in which case you should provide a
+# comma-separated list -- it's primarily used when adding nodes # to legacy clusters
+# that do not have vnodes enabled.
+# initial_token:
+
+# May either be "true" or "false" to enable globally, or contain a list
+# of data centers to enable per-datacenter.
+# hinted_handoff_enabled: DC1,DC2
+# See http://wiki.apache.org/cassandra/HintedHandoff
+hinted_handoff_enabled: true
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, new hints for it will not be
+# created until it has been seen alive and gone down again.
+max_hint_window_in_ms: 10800000 # 3 hours
+# Maximum throttle in KBs per second, per delivery thread.  This will be
+# reduced proportionally to the number of nodes in the cluster.  (If there
+# are two nodes in the cluster, each delivery thread will use the maximum
+# rate; if there are three, each will throttle to half of the maximum,
+# since we expect two nodes to be delivering hints simultaneously.)
+hinted_handoff_throttle_in_kb: 1024
+# Number of threads with which to deliver hints;
+# Consider increasing this number when you have multi-dc deployments, since
+# cross-dc handoff tends to be slower
+max_hints_delivery_threads: 2
+
+# Maximum throttle in KBs per second, total. This will be
+# reduced proportionally to the number of nodes in the cluster.
+batchlog_replay_throttle_in_kb: 1024
+
+# Authentication backend, implementing IAuthenticator; used to identify users
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthenticator,
+# PasswordAuthenticator}.
+#
+# - AllowAllAuthenticator performs no checks - set it to disable authentication.
+# - PasswordAuthenticator relies on username/password pairs to authenticate
+#   users. It keeps usernames and hashed passwords in system_auth.credentials table.
+#   Please increase system_auth keyspace replication factor if you use this authenticator.
+authenticator: AllowAllAuthenticator
+
+# Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthorizer,
+# CassandraAuthorizer}.
+#
+# - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
+# - CassandraAuthorizer stores permissions in system_auth.permissions table. Please
+#   increase system_auth keyspace replication factor if you use this authorizer.
+authorizer: AllowAllAuthorizer
+
+# Validity period for permissions cache (fetching permissions can be an
+# expensive operation depending on the authorizer, CassandraAuthorizer is
+# one example). Defaults to 2000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
+permissions_validity_in_ms: 2000
+
+# The partitioner is responsible for distributing rows (by key) across
+# nodes in the cluster.  Any IPartitioner may be used, including your
+# own as long as it is on the classpath.  Out of the box, Cassandra
+# provides org.apache.cassandra.dht.{Murmur3Partitioner, RandomPartitioner
+# ByteOrderedPartitioner, OrderPreservingPartitioner (deprecated)}.
+#
+# - RandomPartitioner distributes rows across the cluster evenly by md5.
+#   This is the default prior to 1.2 and is retained for compatibility.
+# - Murmur3Partitioner is similar to RandomPartioner but uses Murmur3_128
+#   Hash Function instead of md5.  When in doubt, this is the best option.
+# - ByteOrderedPartitioner orders rows lexically by key bytes.  BOP allows
+#   scanning rows in key order, but the ordering can generate hot spots
+#   for sequential insertion workloads.
+# - OrderPreservingPartitioner is an obsolete form of BOP, that stores
+# - keys in a less-efficient format and only works with keys that are
+#   UTF8-encoded Strings.
+# - CollatingOPP collates according to EN,US rules rather than lexical byte
+#   ordering.  Use this as an example if you need custom collation.
+#
+# See http://wiki.apache.org/cassandra/Operations for more on
+# partitioners and token selection.
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+
+# Directories where Cassandra should store data on disk.  Cassandra
+# will spread data evenly across them, subject to the granularity of
+# the configured compaction strategy.
+data_file_directories:
+- target/db/cassandra/data
+
+# commit log
+commitlog_directory: target/db/cassandra/commitlog
+hints_directory: target/db/cassandra/data/hints
+cdc_raw_directory: target/db/cassandra/data/cdc_raw
+
+# policy for data disk failures:
+# stop: shut down gossip and Thrift, leaving the node effectively dead, but
+#       can still be inspected via JMX.
+# best_effort: stop using the failed disk and respond to requests based on
+#              remaining available sstables.  This means you WILL see obsolete
+#              data at CL.ONE!
+# ignore: ignore fatal errors and let requests fail, as in pre-1.2 Cassandra
+disk_failure_policy: stop
+
+# policy for commit disk failures:
+# stop: shut down gossip and Thrift, leaving the node effectively dead, but
+#       can still be inspected via JMX.
+# stop_commit: shutdown the commit log, letting writes collect but
+#              continuing to service reads, as in pre-2.0.5 Cassandra
+# ignore: ignore fatal errors and let the batches fail
+commit_failure_policy: stop
+
+# Maximum size of the key cache in memory.
+#
+# Each key cache hit saves 1 seek and each row cache hit saves 2 seeks at the
+# minimum, sometimes more. The key cache is fairly tiny for the amount of
+# time it saves, so it's worthwhile to use it at large numbers.
+# The row cache saves even more time, but must contain the entire row,
+# so it is extremely space-intensive. It's best to only use the
+# row cache if you have hot rows or static rows.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(5% of Heap (in MB), 100MB)). Set to 0 to disable key cache.
+key_cache_size_in_mb:
+
+# Duration in seconds after which Cassandra should
+# save the key cache. Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 14400 or 4 hours.
+key_cache_save_period: 14400
+
+# Number of keys from the key cache to save
+# Disabled by default, meaning all keys are going to be saved
+# key_cache_keys_to_save: 100
+
+# Maximum size of the row cache in memory.
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is 0, to disable row caching.
+row_cache_size_in_mb: 0
+
+# Duration in seconds after which Cassandra should
+# safe the row cache. Caches are saved to saved_caches_directory as specified
+# in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 0 to disable saving the row cache.
+row_cache_save_period: 0
+
+# Number of keys from the row cache to save
+# Disabled by default, meaning all keys are going to be saved
+# row_cache_keys_to_save: 100
+
+# The off-heap memory allocator.  Affects storage engine metadata as
+# well as caches.  Experiments show that JEMAlloc saves some memory
+# than the native GCC allocator (i.e., JEMalloc is more
+# fragmentation-resistant).
+#
+# Supported values are: NativeAllocator, JEMallocAllocator
+#
+# If you intend to use JEMallocAllocator you have to install JEMalloc as library and
+# modify cassandra-env.sh as directed in the file.
+#
+# Defaults to NativeAllocator
+# memory_allocator: NativeAllocator
+
+# saved caches
+saved_caches_directory: target/db/cassandra/saved_caches
+
+# commitlog_sync may be either "periodic" or "batch."
+# When in batch mode, Cassandra won't ack writes until the commit log
+# has been fsynced to disk.  It will wait up to
+# commitlog_sync_batch_window_in_ms milliseconds for other writes, before
+# performing the sync.
+#
+# commitlog_sync: batch
+# commitlog_sync_batch_window_in_ms: 50
+#
+# the other option is "periodic" where writes may be acked immediately
+# and the CommitLog is simply synced every commitlog_sync_period_in_ms
+# milliseconds.  By default this allows 1024*(CPU cores) pending
+# entries on the commitlog queue.  If you are writing very large blobs,
+# you should reduce that; 16*cores works reasonably well for 1MB blobs.
+# It should be at least as large as the concurrent_writes setting.
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+# commitlog_periodic_queue_size:
+
+# The size of the individual commitlog file segments.  A commitlog
+# segment may be archived, deleted, or recycled once all the data
+# in it (potentially from each columnfamily in the system) has been
+# flushed to sstables.
+#
+# The default size is 32, which is almost always fine, but if you are
+# archiving commitlog segments (see commitlog_archiving.properties),
+# then you probably want a finer granularity of archiving; 8 or 16 MB
+# is reasonable.
+commitlog_segment_size_in_mb: 32
+
+# any class that implements the SeedProvider interface and has a
+# constructor that takes a Map<String, String> of parameters will do.
+seed_provider:
+# Addresses of hosts that are deemed contact points.
+# Cassandra nodes use this list of hosts to find each other and learn
+# the topology of the ring.  You must change this if you are running
+# multiple nodes!
+- class_name: org.apache.cassandra.locator.SimpleSeedProvider
+  parameters:
+  # seeds is actually a comma-delimited list of addresses.
+  # Ex: "<ip1>,<ip2>,<ip3>"
+  - seeds: "127.0.0.1"
+
+# For workloads with more data than can fit in memory, Cassandra's
+# bottleneck will be reads that need to fetch data from
+# disk. "concurrent_reads" should be set to (16 * number_of_drives) in
+# order to allow the operations to enqueue low enough in the stack
+# that the OS and drives can reorder them.
+#
+# On the other hand, since writes are almost never IO bound, the ideal
+# number of "concurrent_writes" is dependent on the number of cores in
+# your system; (8 * number_of_cores) is a good rule of thumb.
+concurrent_reads: 32
+concurrent_writes: 32
+
+# Total memory to use for sstable-reading buffers.  Defaults to
+# the smaller of 1/4 of heap or 512MB.
+# file_cache_size_in_mb: 512
+
+# Total memory to use for memtables.  Cassandra will flush the largest
+# memtable when this much memory is used.
+# If omitted, Cassandra will set it to 1/4 of the heap.
+# memtable_total_space_in_mb: 2048
+
+# Total space to use for commitlogs.  Since commitlog segments are
+# mmapped, and hence use up address space, the default size is 32
+# on 32-bit JVMs, and 1024 on 64-bit JVMs.
+#
+# If space gets above this value (it will round up to the next nearest
+# segment multiple), Cassandra will flush every dirty CF in the oldest
+# segment and remove it.  So a small total commitlog space will tend
+# to cause more flush activity on less-active columnfamilies.
+# commitlog_total_space_in_mb: 4096
+
+# This sets the amount of memtable flush writer threads.  These will
+# be blocked by disk io, and each one will hold a memtable in memory
+# while blocked. If you have a large heap and many data directories,
+# you can increase this value for better flush performance.
+# By default this will be set to the amount of data directories defined.
+#memtable_flush_writers: 1
+
+# Whether to, when doing sequential writing, fsync() at intervals in
+# order to force the operating system to flush the dirty
+# buffers. Enable this to avoid sudden dirty buffer flushing from
+# impacting read latencies. Almost always a good idea on SSDs; not
+# necessarily on platters.
+trickle_fsync: false
+trickle_fsync_interval_in_kb: 10240
+
+# TCP port, for commands and data
+#storage_port: 7000
+
+# SSL port, for encrypted communication.  Unused unless enabled in
+# encryption_options
+ssl_storage_port: 7001
+
+# Address to bind to and tell other Cassandra nodes to factory to. You
+# _must_ change this if you want multiple nodes to be able to
+# communicate!
+#
+# Leaving it blank leaves it up to InetAddress.getLocalHost(). This
+# will always do the Right Thing _if_ the node is properly configured
+# (hostname, name resolution, etc), and the Right Thing is to use the
+# address associated with the hostname (it might not be).
+#
+# Setting this to 0.0.0.0 is always wrong.
+listen_address: localhost
+
+# Address to broadcast to other Cassandra nodes
+# Leaving this blank will set it to the same value as listen_address
+# broadcast_address: 1.2.3.4
+
+# Internode authentication backend, implementing IInternodeAuthenticator;
+# used to allow/disallow connections from peer nodes.
+# internode_authenticator: org.apache.cassandra.auth.AllowAllInternodeAuthenticator
+
+# Whether to start the native transport server.
+# Please note that the address on which the native transport is bound is the
+# same as the rpc_address. The port however is different and specified below.
+start_native_transport: true
+# port for the CQL native transport to listen for clients on
+#native_transport_port: 9042
+# The maximum threads for handling requests when the native transport is used.
+# This is similar to rpc_max_threads though the default differs slightly (and
+# This is similar to rpc_max_threads though the default differs slightly (and
+# there is no native_transport_min_threads, idle threads will always be stopped
+# after 30 seconds).
+# native_transport_max_threads: 128
+#
+# The maximum size of allowed frame. Frame (requests) larger than this will
+# be rejected as invalid. The default is 256MB.
+# native_transport_max_frame_size_in_mb: 256
+
+# Whether to start the thrift rpc server.
+start_rpc: true
+
+# The address to bind the Thrift RPC service and native transport
+# server -- clients factory here.
+#
+# Leaving this blank has the same effect it does for ListenAddress,
+# (i.e. it will be based on the configured hostname of the node).
+#
+# Note that unlike ListenAddress above, it is allowed to specify 0.0.0.0
+# here if you want to listen on all interfaces, but that will break clients
+# that rely on node auto-discovery.
+rpc_address: localhost
+# port for Thrift to listen for clients on
+#rpc_port: 9160
+
+# enable or disable keepalive on rpc connections
+rpc_keepalive: true
+
+# Cassandra provides two out-of-the-box options for the RPC Server:
+#
+# sync  -> One thread per thrift connection. For a very large number of clients, memory
+#          will be your limiting factor. On a 64 bit JVM, 180KB is the minimum stack size
+#          per thread, and that will correspond to your use of virtual memory (but physical memory
+#          may be limited depending on use of stack space).
+#
+# hsha  -> Stands for "half synchronous, half asynchronous." All thrift clients are handled
+#          asynchronously using a small number of threads that does not vary with the amount
+#          of thrift clients (and thus scales well to many clients). The rpc requests are still
+#          synchronous (one thread per active request).
+#
+# The default is sync because on Windows hsha is about 30% slower.  On Linux,
+# sync/hsha performance is about the same, with hsha of course using less memory.
+#
+# Alternatively,  can provide your own RPC server by providing the fully-qualified class name
+# of an o.a.c.t.TServerFactory that can create an instance of it.
+rpc_server_type: sync
+
+# Uncomment rpc_min|max_thread to set request pool size limits.
+#
+# Regardless of your choice of RPC server (see above), the number of maximum requests in the
+# RPC thread pool dictates how many concurrent requests are possible (but if you are using the sync
+# RPC server, it also dictates the number of clients that can be connected at all).
+#
+# The default is unlimited and thus provides no protection against clients overwhelming the server. You are
+# encouraged to set a maximum that makes sense for you in production, but do keep in mind that
+# rpc_max_threads represents the maximum number of client requests this server may execute concurrently.
+#
+# rpc_min_threads: 16
+# rpc_max_threads: 2048
+
+# uncomment to set socket buffer sizes on rpc connections
+# rpc_send_buff_size_in_bytes:
+# rpc_recv_buff_size_in_bytes:
+
+# Uncomment to set socket buffer size for internode communication
+# Note that when setting this, the buffer size is limited by net.core.wmem_max
+# and when not setting it it is defined by net.ipv4.tcp_wmem
+# See:
+# /proc/sys/net/core/wmem_max
+# /proc/sys/net/core/rmem_max
+# /proc/sys/net/ipv4/tcp_wmem
+# /proc/sys/net/ipv4/tcp_wmem
+# and: man tcp
+# internode_send_buff_size_in_bytes:
+# internode_recv_buff_size_in_bytes:
+
+# Frame size for thrift (maximum message length).
+thrift_framed_transport_size_in_mb: 15
+
+# Set to true to have Cassandra create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of the
+# keyspace data.  Removing these links is the operator's
+# responsibility.
+incremental_backups: false
+
+# Whether or not to take a snapshot before each compaction.  Be
+# careful using this option, since Cassandra won't clean up the
+# snapshots for you.  Mostly useful if you're paranoid when there
+# is a data format change.
+snapshot_before_compaction: false
+
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+auto_snapshot: true
+
+# When executing a scan, within or across a partition, we need to keep the
+# tombstones seen in memory so we can return them to the coordinator, which
+# will use them to make sure other replicas also know about the deleted rows.
+# With workloads that generate a lot of tombstones, this can cause performance
+# problems and even exaust the server heap.
+# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+# Adjust the thresholds here if you understand the dangers and want to
+# scan more tombstones anyway.  These thresholds may also be adjusted at runtime
+# using the StorageService mbean.
+tombstone_warn_threshold: 1000
+tombstone_failure_threshold: 100000
+
+# Add column indexes to a row after its contents reach this size.
+# Increase if your column values are large, or if you have a very large
+# number of columns.  The competing causes are, Cassandra has to
+# deserialize this much of the row to read a single column, so you want
+# it to be small - at least if you do many partial-row reads - but all
+# the index data is read for each access, so you don't want to generate
+# that wastefully either.
+column_index_size_in_kb: 64
+
+# Number of simultaneous compactions to allow, NOT including
+# validation "compactions" for anti-entropy repair.  Simultaneous
+# compactions can help preserve read performance in a mixed read/write
+# workload, by mitigating the tendency of small sstables to accumulate
+# during a single long running compactions. The default is usually
+# fine and if you experience problems with compaction running too
+# slowly or too fast, you should look at
+# compaction_throughput_mb_per_sec first.
+#
+# concurrent_compactors defaults to the number of cores.
+# Uncomment to make compaction mono-threaded, the pre-0.8 default.
+#concurrent_compactors: 1
+
+# Throttles compaction to the given total throughput across the entire
+# system. The faster you insert data, the faster you need to compact in
+# order to keep the sstable count down, but in general, setting this to
+# 16 to 32 times the rate you are inserting data is more than sufficient.
+# Setting this to 0 disables throttling. Note that this account for all types
+# of compaction, including validation compaction.
+compaction_throughput_mb_per_sec: 16
+
+# Throttles all outbound streaming file transfers on this node to the
+# given total throughput in Mbps. This is necessary because Cassandra does
+# mostly sequential IO when streaming data during bootstrap or repair, which
+# can lead to saturating the network connection and degrading rpc performance.
+# When unset, the default is 200 Mbps or 25 MB/s.
+# stream_throughput_outbound_megabits_per_sec: 200
+
+# How long the coordinator should wait for read operations to complete
+read_request_timeout_in_ms: 5000
+# How long the coordinator should wait for seq or index scans to complete
+range_request_timeout_in_ms: 10000
+# How long the coordinator should wait for writes to complete
+write_request_timeout_in_ms: 2000
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+cas_contention_timeout_in_ms: 1000
+# How long the coordinator should wait for truncates to complete
+# (This can be much longer, because unless auto_snapshot is disabled
+# we need to flush first so we can snapshot before removing the data.)
+truncate_request_timeout_in_ms: 60000
+# The default timeout for other, miscellaneous operations
+request_timeout_in_ms: 10000
+
+# Enable operation timeout information exchange between nodes to accurately
+# measure request timeouts.  If disabled, replicas will assume that requests
+# were forwarded to them instantly by the coordinator, which means that
+# under overload conditions we will waste that much extra time processing
+# already-timed-out requests.
+#
+# Warning: before enabling this property make sure to ntp is installed
+# and the times are synchronized between the nodes.
+cross_node_timeout: false
+
+# Enable socket timeout for streaming operation.
+# When a timeout occurs during streaming, streaming is retried from the start
+# of the current file. This _can_ involve re-streaming an important amount of
+# data, so you should avoid setting the value too low.
+# Default value is 0, which never timeout streams.
+# streaming_socket_timeout_in_ms: 0
+
+# phi value that must be reached for a host to be marked down.
+# most users should never need to adjust this.
+# phi_convict_threshold: 8
+
+# endpoint_snitch -- Set this to a class that implements
+# IEndpointSnitch.  The snitch has two functions:
+# - it teaches Cassandra enough about your network topology to route
+#   requests efficiently
+# - it allows Cassandra to spread replicas around your cluster to avoid
+#   correlated failures. It does this by grouping machines into
+#   "datacenters" and "racks."  Cassandra will do its best not to have
+#   more than one replica on the same "rack" (which may not actually
+#   be a physical location)
+#
+# IF YOU CHANGE THE SNITCH AFTER DATA IS INSERTED INTO THE CLUSTER,
+# YOU MUST RUN A FULL REPAIR, SINCE THE SNITCH AFFECTS WHERE REPLICAS
+# ARE PLACED.
+#
+# Out of the box, Cassandra provides
+#  - SimpleSnitch:
+#    Treats Strategy order as proximity. This improves cache locality
+#    when disabling read repair, which can further improve throughput.
+#    Only appropriate for single-datacenter deployments.
+#  - PropertyFileSnitch:
+#    Proximity is determined by rack and data center, which are
+#    explicitly configured in cassandra-topology.properties.
+#  - GossipingPropertyFileSnitch
+#    The rack and datacenter for the local node are defined in
+#    cassandra-rackdc.properties and propagated to other nodes via gossip.  If
+#    cassandra-topology.properties exists, it is used as a fallback, allowing
+#    migration from the PropertyFileSnitch.
+#  - RackInferringSnitch:
+#    Proximity is determined by rack and data center, which are
+#    assumed to correspond to the 3rd and 2nd octet of each node's
+#    IP address, respectively.  Unless this happens to match your
+#    deployment conventions (as it did Facebook's), this is best used
+#    as an example of writing a custom Snitch class.
+#  - Ec2Snitch:
+#    Appropriate for EC2 deployments in a single Region. Loads Region
+#    and Availability Zone information from the EC2 API. The Region is
+#    treated as the datacenter, and the Availability Zone as the rack.
+#    Only private IPs are used, so this will not work across multiple
+#    Regions.
+#  - Ec2MultiRegionSnitch:
+#    Uses public IPs as broadcast_address to allow cross-region
+#    connectivity.  (Thus, you should set seed addresses to the public
+#    IP as well.) You will need to open the storage_port or
+#    ssl_storage_port on the public IP firewall.  (For intra-Region
+#    traffic, Cassandra will switch to the private IP after
+#    establishing a connection.)
+#
+# You can use a custom Snitch by setting this to the full class name
+# of the snitch, which will be assumed to be on your classpath.
+endpoint_snitch: SimpleSnitch
+
+# controls how often to perform the more expensive part of host score
+# calculation
+dynamic_snitch_update_interval_in_ms: 100
+# controls how often to reset all host scores, allowing a bad host to
+# possibly recover
+dynamic_snitch_reset_interval_in_ms: 600000
+# if set greater than zero and read_repair_chance is < 1.0, this will allow
+# 'pinning' of replicas to hosts in order to increase cache capacity.
+# The badness threshold will control how much worse the pinned host has to be
+# before the dynamic snitch will prefer other replicas over it.  This is
+# expressed as a double which represents a percentage.  Thus, a value of
+# 0.2 means Cassandra would continue to prefer the static snitch values
+# until the pinned host was 20% worse than the fastest.
+dynamic_snitch_badness_threshold: 0.1
+
+# request_scheduler -- Set this to a class that implements
+# RequestScheduler, which will schedule incoming client requests
+# according to the specific policy. This is useful for multi-tenancy
+# with a single Cassandra cluster.
+# NOTE: This is specifically for requests from the client and does
+# not affect inter node communication.
+# org.apache.cassandra.scheduler.NoScheduler - No scheduling takes place
+# org.apache.cassandra.scheduler.RoundRobinScheduler - Round robin of
+# client requests to a node with a separate queue for each
+# request_scheduler_id. The scheduler is further customized by
+# request_scheduler_options as described below.
+request_scheduler: org.apache.cassandra.scheduler.NoScheduler
+
+# Scheduler Options vary based on the type of scheduler
+# NoScheduler - Has no options
+# RoundRobin
+#  - throttle_limit -- The throttle_limit is the number of in-flight
+#                      requests per client.  Requests beyond
+#                      that limit are queued up until
+#                      running requests can complete.
+#                      The value of 80 here is twice the number of
+#                      concurrent_reads + concurrent_writes.
+#  - default_weight -- default_weight is optional and allows for
+#                      overriding the default which is 1.
+#  - weights -- Weights are optional and will default to 1 or the
+#               overridden default_weight. The weight translates into how
+#               many requests are handled during each turn of the
+#               RoundRobin, based on the scheduler id.
+#
+# request_scheduler_options:
+#    throttle_limit: 80
+#    default_weight: 5
+#    weights:
+#      Keyspace1: 1
+#      Keyspace2: 5
+
+# request_scheduler_id -- An identifier based on which to perform
+# the request scheduling. Currently the only valid option is keyspace.
+# request_scheduler_id: keyspace
+
+# Enable or disable inter-node encryption
+# Default settings are TLS v1, RSA 1024-bit keys (it is imperative that
+# users generate their own keys) TLS_RSA_WITH_AES_128_CBC_SHA as the cipher
+# suite for authentication, key exchange and encryption of the actual data transfers.
+# NOTE: No custom encryption options are enabled at the moment
+# The available internode options are : all, none, dc, rack
+#
+# If set to dc cassandra will encrypt the traffic between the DCs
+# If set to rack cassandra will encrypt the traffic between the racks
+#
+# The passwords used in these options must match the passwords used when generating
+# the keystore and truststore.  For instructions on generating these files, see:
+# http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
+#
+server_encryption_options:
+  internode_encryption: none
+  keystore: conf/.keystore
+  keystore_password: cassandra
+  truststore: conf/.truststore
+  truststore_password: cassandra
+  # More advanced defaults below:
+  # protocol: TLS
+  # algorithm: SunX509
+  # store_type: JKS
+  # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA]
+  # require_client_auth: false
+
+# enable or disable client/server encryption.
+client_encryption_options:
+  enabled: false
+  keystore: conf/.keystore
+  keystore_password: cassandra
+  # require_client_auth: false
+  # Set trustore and truststore_password if require_client_auth is true
+  # truststore: conf/.truststore
+  # truststore_password: cassandra
+  # More advanced defaults below:
+  # protocol: TLS
+  # algorithm: SunX509
+  # store_type: JKS
+  # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA]
+
+# internode_compression controls whether traffic between nodes is
+# compressed.
+# can be:  all  - all traffic is compressed
+#          dc   - traffic between different datacenters is compressed
+#          none - nothing is compressed.
+internode_compression: all
+
+# Enable or disable tcp_nodelay for inter-dc communication.
+# Disabling it will result in larger (but fewer) network packets being sent,
+# reducing overhead from the TCP protocol itself, at the cost of increasing
+# latency if you block for cross-datacenter responses.
+inter_dc_tcp_nodelay: false

--- a/querygen/test-integration/conf/grakn.properties
+++ b/querygen/test-integration/conf/grakn.properties
@@ -1,0 +1,76 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+############################# Knowledge Base Configuration #############################
+
+# Number of instances after which Grakn should shard any type node. Sharding is the
+# mechanism by which Grakn mitigates against supernodes.
+# A larger sharding threshold will increase runtime as the knowledge base  grows and decrease
+# the likelihood of supernodes. A threshold that is too small will create supernodes
+# more frequently.
+knowledge-base.sharding-threshold=10000
+
+############################# Server Configuration #############################
+
+# Directory in which server data will be stored
+data-dir=server/db/
+
+# Set the IP address that Grakn server server will listen on.
+server.host=0.0.0.0
+
+# Port number to use for gRPC server to listen on
+grpc.port=48555
+
+############################# Logging Configuration #############################
+# These properties are read directly by logback.xml
+
+# Single directory under which to store log files. If using a relative path it will be relative
+# to the JVM system variable "grakn.dir"
+log.dirs=./logs/
+
+# Specify the log verbosity level. This can be one of:
+#
+# ERROR: (critical errors indicating the application has failed)
+# WARN:  (errors that will not affect the overall running of the application)
+# INFO:  (minimally verbose, including Grakn server lifecycle events)
+# DEBUG: (verbose, non production use, server task lifecycle events)
+# TRACE: (extraordinarily verbose, be brave, including graql query traversal paths,
+#         extra task lifecycle events, kafka consumer offsets, etc)
+log.level=INFO
+
+############################# Persisted Knowledge Base Configuration #############################
+# The hostname or comma-separated list of hostnames of storage backend servers
+storage.hostname=127.0.0.1
+# Timeout in milliseconds when connecting to storage backend
+storage.connection-timeout=20000
+
+# Whether to enable the database-level cache, which is shared across all transactions.
+# Enabling this option speeds up traversals by holding hot elements in memory,
+# but also increases the likelihood of reading stale data. Disabling it forces each transaction
+# to independently fetch elements from storage before reading/writing them.
+cache.db-cache=false
+# How long in milliseconds database-level cache will keep entries after flushing them.
+cache.db-cache-clean-wait=20
+# Default expiration time in milliseconds for entries in the database-level cache.
+# Set to 0 to disable expiration (cache entries live forever or until memory pressure
+# triggers eviction).
+cache.db-cache-time=5000
+# Size of Janus's database cache in proportion to JVM size 0 (small) to 1 (large)
+cache.db-cache-size=0.35
+cache.tx-cache-size=30000
+cache.tx-dirty-size=4096

--- a/querygen/test-integration/resources/BUILD
+++ b/querygen/test-integration/resources/BUILD
@@ -1,0 +1,24 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2019 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+filegroup(
+    name = "logback-test",
+    srcs = ["logback.xml"],
+    visibility = ["//visibility:public"]
+)
+

--- a/querygen/test-integration/resources/BUILD
+++ b/querygen/test-integration/resources/BUILD
@@ -22,3 +22,5 @@ filegroup(
     visibility = ["//visibility:public"]
 )
 
+
+exports_files(["schema.gql"])

--- a/querygen/test-integration/resources/logback.xml
+++ b/querygen/test-integration/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration debug="false">
+    <!--Configure the standard out appender used to print the Grakn logo-->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO"/>
+
+    <logger name="grakn.benchmark" level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+</configuration>

--- a/querygen/test-integration/resources/schema.gql
+++ b/querygen/test-integration/resources/schema.gql
@@ -2,6 +2,13 @@ define
     person sub entity,
         plays spouse,
         has name;
+
+    subperson sub person,
+        plays foo,
+        has name;
     name sub attribute, datatype string;
     marriage sub relation,
         relates spouse;
+
+    bar sub relation,
+        relates foo;

--- a/querygen/test-integration/resources/schema.gql
+++ b/querygen/test-integration/resources/schema.gql
@@ -1,0 +1,7 @@
+define
+    person sub entity,
+        plays spouse,
+        has name;
+    name sub attribute, datatype string;
+    marriage sub relation,
+        relates spouse;

--- a/querygen/test-integration/resources/schema.gql
+++ b/querygen/test-integration/resources/schema.gql
@@ -1,14 +1,955 @@
 define
-    person sub entity,
-        plays spouse,
-        has name;
 
-    subperson sub person,
-        plays foo,
-        has name;
-    name sub attribute, datatype string;
-    marriage sub relation,
-        relates spouse;
+################
+## ATTRIBUTES ##
+################
+	name sub attribute,
+		datatype string;
+	full-name sub name;
+	nickname sub name;
 
-    bar sub relation,
-        relates foo;
+	title sub attribute,
+		datatype string;
+
+	event-date sub attribute,
+		abstract,
+		datatype date;
+	approved-date sub event-date;
+	birth-date sub event-date;
+	start-date sub event-date;
+	end-date sub event-date;
+	engagement-date sub event-date;
+
+	published-date sub attribute,
+		datatype date;
+
+	reference-id sub attribute,
+		datatype string;
+
+	salary sub attribute,
+		datatype long;
+
+	registration-number sub attribute,
+		datatype string;
+
+	identifier sub attribute,
+    		datatype string;
+
+	graduated sub attribute,
+		datatype boolean;
+
+	score sub attribute,
+		datatype double;
+
+	ranking sub attribute,
+		datatype long;
+
+	phone-number sub attribute,
+		datatype string;
+
+	email sub attribute,
+		datatype string;
+
+	gender sub attribute,
+		datatype string;
+
+	engaged sub attribute,
+		datatype boolean;
+	separated sub attribute,
+		datatype boolean;
+	divorced sub attribute,
+		datatype boolean;
+
+	file sub attribute,
+		datatype string;
+
+	caption sub attribute,
+		datatype string;
+
+	language sub attribute,
+		datatype string,
+		plays spoken,
+		plays mutual-language;
+
+	content sub attribute,
+		datatype string,
+		has language;
+
+	emotion sub attribute,
+		datatype string,
+		regex "^(like|love|funny|shocking|sad|angry)$",
+		plays reacted-emotion;
+
+	link sub attribute,
+		datatype string,
+		plays attached;
+
+	person sub entity,
+		has full-name,
+		has nickname,
+		has gender,
+		has phone-number,
+		key email;
+
+###################
+## GENERIC TYPES ##
+###################
+
+	location-of-everything sub relation,
+		abstract,
+		relates located-subject,
+		relates subject-location;
+
+	location-hierarchy sub relation,
+		relates subordinate-location,
+		relates superior-location;
+
+	ownership sub relation,
+		relates owner,
+		relates owned;
+
+	location sub entity,
+		key name,
+		plays subordinate-location,
+		plays superior-location;
+
+	request sub relation,
+		relates approved-subject,
+		relates requester,
+		relates respondent;
+
+	periodic-event sub relation,
+		abstract,
+		has start-date,
+		has end-date,
+		plays overlapped-event;
+
+	########################
+	## events overlapping ##
+	########################
+
+	event-overlapping sub relation,
+		relates overlapped-event;
+
+#	events-overlap sub rule,
+#		when {
+#			$e1 isa periodic-event;
+#			$e1 has start-date $sd1, has end-date $ed1;
+#			$e2 isa periodic-event;
+#			$e2 has start-date $sd2, has end-date $ed2;
+#			$sd2 > $sd1;
+#			$sd2 < $ed1;
+#			$e1 != $e2;
+#		}, then {
+#			(overlapped-event: $e1, overlapped-event: $e2) isa event-overlapping;
+#		};
+
+###########
+## BIRTH ##
+###########
+
+## query the schema section
+# match
+# 	$per sub person;
+# 	$lob sub location-of-birth;
+# 	$bir sub birth;
+# 	$loc sub location;
+# 	$blm sub birth-location-mutuality;
+# get;
+
+	location-of-birth sub location-of-everything,
+		relates located-birth as located-subject,
+		relates birth-location as subject-location;
+
+	birth sub relation,
+		has birth-date,
+		relates birthed-child,
+		plays located-birth,
+		plays mutual-birth;
+
+	person sub entity,
+		plays birthed-child,
+		plays mutual-birthed-child;
+
+	location sub entity,
+		plays birth-location,
+		plays mutual-birth-location;
+
+	##############################
+	## birth location in common ##
+	##############################
+
+	birth-mutuality sub relation,
+		relates mutual-birthed-child,
+		relates mutual-birth-location,
+		relates mutual-birth;
+#
+#	people-born-at-the-same-location sub rule,
+#		when {
+#			$b1 (birthed-child: $p1) isa birth;
+#			$b2 (birthed-child: $p2) isa birth;
+#			($b1, birth-location: $l) isa location-of-birth;
+#			($b2, birth-location: $l) isa location-of-birth;
+#			$p1 != $p2;
+#		}, then {
+#			(mutual-birthed-child: $p1, mutual-birthed-child: $p2, mutual-birth-location: $l, mutual-birth: $b1, mutual-birth: $b2) isa birth-mutuality;
+#		};
+
+    parentship sub relation,
+  		relates parent,
+		relates child,
+		relates father as parent,
+		relates mother as parent,
+		relates son as child,
+		relates daughter as child;
+
+	person-with-a-mother sub entity;
+	person-with-a-father sub entity;
+
+#	genderizeParentships1
+#	when{
+#		(parent: $p, child: $c) isa parentship;
+#		$p has gender 'male';
+#		$c has gender 'male';
+#	}, then{
+#		(father: $p, son: $c) isa parentship;
+#	};
+#
+#	genderizeParentships2
+#	when{
+#		(parent: $p, child: $c) isa parentship;
+#		$p has gender 'male';
+#		$c has gender 'female';
+#	}, then{
+#		(father: $p, daughter: $c) isa parentship;
+#	};
+#
+#	genderizeParentships3
+#	when{
+#		(parent: $p, child: $c) isa parentship;
+#		$p has gender 'female';
+#		$c has gender 'male';
+#	}, then{
+#		(mother: $p, son: $c) isa parentship;
+#	};
+#
+#	genderizeParentships4
+#	when{
+#		(parent: $p, child: $c) isa parentship;
+#		$p has gender 'female';
+#		$c has gender 'female';
+#	}, then{
+#		(mother: $p, daughter: $c) isa parentship;
+#	};
+
+###############
+## RESIDENCY ##
+###############
+
+## query the schema section
+# match
+# 	$per sub person;
+# 	$lor sub location-of-residence;
+# 	$res sub residency;
+# 	$loc sub location;
+# get;
+
+	location-of-residence sub location-of-everything,
+		relates located-residence as located-subject,
+		relates residence as subject-location;
+
+	residency sub periodic-event,
+		relates resident,
+		plays located-residence,
+		plays mutual-residency;
+
+	person sub entity,
+		plays resident,
+		plays mutual-resident;
+
+	location sub entity,
+		plays residence,
+		plays mutual-residence;
+
+	#########################
+	## residence in common ##
+	#########################
+
+	residence-mutuality sub relation,
+		relates mutual-resident,
+		relates mutual-residency,
+		relates mutual-residence;
+
+#	people-resided-at-the-same-location sub rule,
+#		when {
+#			$r1 (resident: $p1) isa residency;
+#			$r2 (resident: $p2) isa residency;
+#			($r1, residence: $l) isa location-of-residence;
+#			($r2, residence: $l) isa location-of-residence;
+#			$p1 != $p2;
+#		}, then {
+#			(mutual-resident: $p1, mutual-resident: $p2, mutual-residence: $l, mutual-residency: $r1, mutual-residency: $r2) isa residence-mutuality;
+#		};
+
+###############
+## EDUCATION ##
+###############
+
+## query the schema section
+# match
+# 	$sco sub school-course-offerring;
+# 	$los sub location-of-school;
+# 	$sce sub school-course-enrollment;
+# 	$sch sub school;
+# 	$scc sub school-course;
+# 	$per sub person;
+# 	$loc sub location;
+# get;
+
+	location-of-school sub location-of-everything,
+		relates located-school as located-subject,
+		relates school-location as subject-location;
+
+	school-course-enrollment sub periodic-event,
+		has graduated,
+		has score,
+		relates student,
+		relates enrolled-course,
+		relates enrolling-school,
+		plays mutual-course-enrollment;
+
+	school sub entity,
+		key name,
+		has ranking,
+		plays offerring-school,
+		plays located-school,
+		plays enrolling-school,
+		plays mutual-school;
+
+	school-course sub entity,
+		key title,
+		plays offered-course,
+		plays enrolled-course;
+
+	person sub entity,
+		plays student,
+		plays schoolmate,
+		plays coursemate;
+
+	location sub entity,
+		plays school-location;
+
+	##########################
+	## school offerings ##
+	##########################
+
+	school-course-offerring sub relation,
+		relates offerring-school,
+		relates offered-course;
+
+#	school-offers-the-enrolled-courses sub rule,
+#		when {
+#			(student: $p, enrolled-course: $c, enrolling-school: $s) isa school-course-enrollment;
+#		}, then {
+#			(offerring-school: $s, offered-course: $c) isa school-course-offerring;
+#		};
+
+	##########################
+	## educations in common ##
+	##########################
+
+	school-mutuality sub relation,
+		relates schoolmate,
+		relates mutual-school;
+#
+#	people-gone-to-the-same-school sub rule,
+#		when {
+#			(student: $p1, enrolled-course: $c1) isa school-course-enrollment;
+#			(student: $p2, enrolled-course: $c2) isa school-course-enrollment;
+#			(offered-course: $c1, offerring-school: $s) isa school-course-offerring;
+#			(offered-course: $c2, offerring-school: $s) isa school-course-offerring;
+#			$p1 != $p2;
+#		}, then {
+#			(schoolmate: $p1, schoolmate: $p2, mutual-school: $s) isa school-mutuality;
+#		};
+
+	course-enrollment-mutuality sub relation,
+		relates coursemate,
+		relates mutual-course-enrollment;
+
+#	people-taken-the-same-course sub rule,
+#		when {
+#			$sce1 (student: $p1, enrolled-course: $sc) isa school-course-enrollment;
+#			$sce2 (student: $p2, enrolled-course: $sc) isa school-course-enrollment;
+#			$p1 != $p2;
+#		}, then {
+#			(coursemate: $p1, coursemate: $p2, mutual-course-enrollment: $sce1, mutual-course-enrollment: $sce2) isa course-enrollment-mutuality;
+#		};
+
+############
+## TRAVEL ##
+############
+
+## query the schema section
+# match
+# 	$lot sub location-of-travel;
+# 	$tra sub travel;
+# 	$per sub person;
+# 	$loc sub location;
+# get;
+
+	location-of-travel sub location-of-everything,
+		relates located-travel as located-subject,
+		relates travel-location as subject-location;
+
+	travel sub periodic-event,
+		relates traveler,
+		plays located-travel,
+		plays mutual-travel;
+
+	person sub entity,
+		plays traveler,
+		plays mutual-traveler;
+
+	location sub entity,
+		plays travel-location,
+		plays mutual-travel-location;
+
+	#######################
+	## travels in common ##
+	#######################
+
+	travel-mutuality sub relation,
+		relates mutual-traveler,
+		relates mutual-travel,
+		relates mutual-travel-location;
+
+#	people-traveled-to-the-same-location sub rule,
+#		when {
+#			$t1 (traveler: $p1) isa travel;
+#			$t2 (traveler: $p2) isa travel;
+#			($t1, travel-location: $l) isa location-of-travel;
+#			($t2, travel-location: $l) isa location-of-travel;
+#			$p1 != $p2;
+#		}, then {
+#			(mutual-traveler: $p1, mutual-traveler: $p2, mutual-travel-location: $l, mutual-travel: $t1, mutual-travel: $t2) isa travel-mutuality;
+#		};
+
+##########
+## WORK ##
+##########
+
+## query the schema section
+# match
+# 	$oow sub office-ownership;
+# 	$emp sub employment;
+# 	$loo sub location-of-office;
+# 	$wpo sub work-position;
+# 	$org sub organisation;
+# 	$off sub office;
+# 	$loc sub location;
+# 	$per sub person;
+# 	$emm sub employment-mutuality;
+# 	$wpm sub work-position-mutuality;
+# get;
+
+	employment sub periodic-event,
+		key reference-id,
+		has salary,
+		relates employer,
+		relates employee,
+		relates offered-position,
+		plays mutual-employment;
+
+	location-of-office sub location-of-everything,
+		relates located-office as located-subject,
+		relates office-location as subject-location;
+
+	office-ownership sub ownership,
+		relates office-owner as owner,
+		relates owned-office as owned;
+
+	work-position sub entity,
+		key title,
+		plays offered-position,
+		plays mutual-position;
+
+	organisation sub entity,
+		key name,
+		key registration-number,
+		plays office-owner,
+		plays employer,
+		plays mutual-organisation;
+
+	office sub entity,
+	    key registration-number,
+		plays owned-office,
+		plays located-office;
+
+	location sub entity,
+		plays office-location;
+
+	person sub entity,
+		plays employee,
+		plays mutual-employee;
+
+	##########################
+	## employment in common ##
+	##########################
+
+	employment-mutuality sub relation,
+		relates mutual-employee,
+		relates mutual-employment,
+		relates mutual-organisation;
+
+#	people-work-at-the-same-organisation sub rule,
+#		when {
+#			$e1 (employee: $p1, employer: $o) isa employment;
+#			$e2 (employee: $p2, employer: $o) isa employment;
+#			$p1 != $p2;
+#		}, then {
+#			(mutual-employee: $p1, mutual-employee: $p2, mutual-organisation: $o, mutual-employment: $e1, mutual-employment: $e2) isa employment-mutuality;
+#		};
+
+	work-position-mutuality sub relation,
+		relates mutual-employee,
+		relates mutual-employment,
+		relates mutual-position;
+
+#	people-work-at-the-same-position sub rule,
+#		when {
+#			$e1 (employee: $p1, offered-position: $p) isa employment;
+#			$e2 (employee: $p2, offered-position: $p) isa employment;
+#			$p1 != $p2;
+#		}, then {
+#			(mutual-employee: $p1, mutual-employee: $p2, mutual-position: $p, mutual-employment: $e1, mutual-employment: $e2) isa work-position-mutuality;
+#		};
+
+##############
+## Language ##
+##############
+
+## query the schema section
+# match
+# 	$sol sub speaking-of-language;
+# 	$per sub person;
+# 	$lan sub language;
+# 	$slm sub speaking-language-mutuality;
+# get;
+
+	speaking-of-language sub relation,
+		relates speaker,
+		relates spoken,
+		plays mutual-language-speaking;
+
+	person sub entity,
+		plays speaker,
+		plays mutual-speaker;
+
+	##################################
+	## speaking languages in common ##
+	##################################
+
+	speaking-language-mutuality sub relation,
+		relates mutual-speaker,
+		relates mutual-language-speaking,
+		relates mutual-language;
+
+#	people-speak-the-same-language sub rule,
+#		when {
+#			$sol1 (speaker: $p1, spoken: $l) isa speaking-of-language;
+#			$sol2 (speaker: $p2, spoken: $l) isa speaking-of-language;
+#			$p1 != $p2;
+#		}, then {
+#			(mutual-speaker: $p1, mutual-speaker: $p2, mutual-language: $l, mutual-language-speaking: $sol1, mutual-language-speaking: $sol2) isa speaking-language-mutuality;
+#		};
+
+#########################
+## RELATIONSHIP STATUS ##
+#########################
+
+## query the schema section
+# match
+# 	$ror sub romantic-relationship;
+# 	$mar sub marriage;
+# 	$per sub person;
+# get;
+
+	romantic-relationship sub relation,
+		has start-date,
+		has end-date,
+		has engaged,
+		has engagement-date,
+		relates partner;
+
+	open-relationship sub romantic-relationship,
+		relates partner;
+
+	domestic-relationship sub romantic-relationship,
+		relates partner;
+
+	complicated-relationship sub romantic-relationship,
+		relates partner;
+
+	marriage sub relation,
+		has start-date,
+		has end-date,
+		has separated,
+		has divorced,
+		relates husband,
+		relates wife,
+		relates spouse;
+
+	person sub entity,
+		plays partner,
+		plays spouse,
+		plays wife,
+		plays husband;
+
+################
+## FRIENDSHIP ##
+################
+
+## query the schema section
+# match
+# 	$fri sub friendship;
+# 	$frr sub friend-request;
+# 	$frl sub friends-list;
+# 	$per sub person;
+# 	$muf sub mutual-friendship;
+# get;
+
+	friendship sub relation,
+		relates friend,
+		plays approved-friendship,
+		plays listed-friendship;
+
+	friend-request sub request,
+		has approved-date,
+		relates approved-friendship as approved-subject,
+		relates friendship-requester as requester,
+		relates friendship-respondent as respondent;
+
+	friends-list sub relation,
+		has title,
+		relates list-owner,
+		relates listed-friendship;
+
+	person sub entity,
+		plays friend,
+		plays friendship-requester,
+		plays friendship-respondent,
+		plays list-owner,
+		plays mutual-friend,
+		plays one-degree-friend;
+
+	#######################
+	## mutual friendship ##
+	#######################
+
+	mutual-friendship sub relation,
+		relates mutual-friend,
+		relates one-degree-friend;
+
+#	people-have-mutual-friends sub rule,
+#		when {
+#			($p1, $p2) isa friendship;
+#			($p2, $p3) isa friendship;
+#		}, then {
+#			(one-degree-friend: $p1, one-degree-friend: $p3, mutual-friend: $p2) isa mutual-friendship;
+#		};
+
+###########
+## GROUP ##
+###########
+
+## query the schema section
+# match
+# 	$gro sub group-ownership;
+# 	$grm sub group-membership;
+# 	$gmr sub group-membership-request;
+# 	$pug sub public-group;
+# 	$clg sub closed-group;
+# 	$seg sub secret-group;
+# 	$per sub person;
+# get;
+
+	group-ownership sub ownership,
+		relates group-owner as owner,
+		relates owned-group as owned;
+
+	group-membership sub relation,
+		has approved-date,
+		plays approved-group-membership,
+		relates group-member,
+		relates membership-grouping;
+
+	group-membership-request sub request,
+		has approved-date,
+		relates approved-group-membership as approved-subject,
+		relates group-membership-requester as requester,
+		relates group-membership-respondent as respondent;
+
+	social-group sub entity,
+		abstract,
+		key name,
+		plays owned-group,
+		plays membership-grouping,
+		plays shared-in;
+
+	public-group sub social-group;
+
+	closed-group sub social-group;
+
+	secret-group sub social-group;
+
+	person sub entity,
+		plays group-owner,
+		plays group-member,
+		plays group-membership-requester,
+		plays group-membership-respondent;
+
+	#####################################
+	## public group membership request ##
+	#####################################
+
+#	public-group-membership-is-automatically-approved sub rule,
+#		when {
+#			$group isa public-group;
+#			(group-owner: $owner, owned-group: $group) isa group-ownership;
+#			$membership (group-member: $member, membership-grouping: $group) isa group-membership;
+#		}, then {
+#			(approved-group-membership: $membership, group-membership-requester: $member, group-membership-respondent: $owner) isa group-membership-request;
+#		};
+#
+#	###################################
+#	## group owner is always member ##
+#	###################################
+#
+#	group-owner-is-always-member sub rule,
+#		when {
+#			$group isa social-group;
+#			(group-owner: $owner, owned-group: $group) isa group-ownership;
+#		}, then {
+#			(group-member: $owner, membership-grouping: $group) isa group-membership;
+#		};
+
+##############
+## TIMELINE ##
+##############
+
+## query the schema section
+# match
+# 	$tow sub timeline-ownership;
+# 	$tim sub timeline;
+# 	$per sub person;
+# get;
+
+	timeline-ownership sub ownership,
+		relates timeline-owner as owner,
+		relates owned-timeline as owned;
+
+	timeline sub entity,
+	    key identifier,
+		plays owned-timeline,
+		plays shared-in;
+
+	person sub entity,
+		plays timeline-owner;
+
+##########
+## POST ##
+##########
+
+## query the schema section
+# match
+# 	$rep sub reply;
+# 	$tag sub tagging;
+# 	$att sub attachment;
+# 	$rea sub reaction;
+# 	$emo sub emotion;
+# 	$lin sub link;
+# 	$stu sub status-update;
+# 	$com sub comment;
+# 	$mow sub media-ownership;
+# 	$alb sub album;
+# 	$vid sub video;
+# 	$pho sub photo;
+# 	$per sub person;
+# get;
+
+	reply sub relation,
+		relates replied-to,
+		relates reply-content,
+		relates replied-by;
+
+	tagging sub relation,
+		relates tagged,
+		relates tagged-in;
+
+	attachment sub relation,
+		relates attached,
+		relates attached-to;
+
+	reaction sub relation,
+		relates reacted-emotion,
+		relates reacted-to,
+		relates reacted-by;
+
+	post sub entity,
+		abstract,
+		key identifier,
+		plays permitted-content,
+		plays shared-content,
+		plays replied-to,
+		plays tagged-in,
+		plays reacted-to;
+
+	status-update sub post,
+		has content,
+		plays attached-to;
+
+	comment sub post,
+		has content,
+		plays reply-content,
+		plays attached-to;
+
+	media-ownership sub ownership,
+		relates media-owner as owner,
+		relates owned-media as owned;
+
+	album sub post,
+		has title,
+		has published-date,
+		plays media-owner;
+
+	media sub post,
+		abstract,
+		has caption,
+		has file,
+		plays owned-media,
+		plays attached;
+
+	video sub media;
+
+	photo sub media;
+
+	person sub entity,
+		plays tagged,
+		plays reacted-by,
+		plays replied-by;
+
+#############
+## SHARING ##
+#############
+
+## query the schema section
+# match
+# 	$pus sub public-sharing;
+# 	$frs sub friends-sharing;
+# 	$ins sub inclusive-sharing;
+# 	$fes sub friends-with-exclusion-sharing;
+# 	$prs sub private-sharing;
+# 	$pos sub post;
+# 	$pts sub permitted-to-see;
+# 	$per sub person;
+# 	$puu sub public-user;
+# get;
+
+	sharing sub relation,
+		abstract,
+		relates shared-content,
+		relates shared-by,
+		relates shared-in;
+
+	public-sharing sub sharing,
+		relates shared-content,
+		relates shared-by,
+		relates shared-in;
+
+	friends-sharing sub sharing,
+		relates shared-content,
+		relates shared-by,
+		relates shared-in;
+
+	inclusive-sharing sub sharing,
+		relates shared-content,
+		relates shared-by,
+		relates shared-in,
+		relates shared-with;
+
+	friends-with-exclusion-sharing sub sharing,
+		relates shared-content,
+		relates shared-by,
+		relates shared-in,
+		relates hidden-from;
+
+	private-sharing sub sharing,
+		relates shared-content,
+		relates shared-in,
+		relates shared-by;
+
+	permitted-to-see sub relation,
+		relates permitted-content,
+		relates permission-grantee;
+
+	person sub entity,
+		plays shared-by,
+		plays shared-with,
+		plays hidden-from,
+		plays permission-grantee;
+
+	public-user sub entity,
+		plays permission-grantee;
+#
+#	###########################
+#	## posts view permission ##
+#	###########################
+#
+#	public-permission sub rule,
+#		when {
+#			(shared-content: $sc) isa public-sharing;
+#			$pu isa public-user;
+#		}, then {
+#			(permitted-content: $sc, permission-grantee: $pu) isa permitted-to-see;
+#		};
+#
+#	friends-permission sub rule,
+#		when {
+#			(shared-content: $sc, shared-by: $sb) isa friends-sharing;
+#			(friend: $sb, $f) isa friendship;
+#		}, then {
+#			(permitted-content: $sc, permission-grantee: $f) isa permitted-to-see;
+#		};
+#
+#	inclusive-permissions sub rule,
+#		when {
+#			(shared-content: $sc, shared-with: $sw) isa inclusive-sharing;
+#		}, then {
+#			(permitted-content: $sc, permission-grantee: $sw) isa permitted-to-see;
+#		};
+#
+#	friends-excluded-permission sub rule,
+#		when {
+#			(shared-content: $sc, shared-by: $sb, hidden-from: $hf) isa friends-with-exclusion-sharing;
+#			(friend: $sb, $f) isa friendship;
+#			$f != $hf;
+#		}, then {
+#			(permitted-content: $sc, permission-grantee: $f) isa permitted-to-see;
+#		};
+#
+#	private-permission sub rule,
+#		when {
+#			(shared-content: $sc, shared-by: $sb) isa private-sharing;
+#			$pu isa public-user;
+#		}, then {
+#			(permitted-content: $sc, permission-grantee: $sb) isa permitted-to-see;
+#		};
+#
+#	author-permission sub rule,
+#		when {
+#			(shared-content: $sc, shared-by: $sb) isa sharing;
+#			$pu isa public-user;
+#		}, then {
+#            (permitted-content: $sc, permission-grantee: $sb) isa permitted-to-see;
+#        };


### PR DESCRIPTION
## What is the goal of this PR?
Query generator that consumes a keyspace and generates a set number of queries with varying levels of ambiguity, specificity, number of attributes and role players etc.

The goal is to be able to generate plausible queries according to a schema. Note that a single schema permits many different shapes of data (eg. a marriage between `spouse` roles may in practice only have a maximum of 2 role players, but the schema allows infinite).

The first version should allow generating according to a schema. Implements point one in #300. 

## What are the changes implemented in this PR?
* new package `querygen`
* subpackages `src` and `test-integration`
* add license headers to some missing files
