### PR TITLE
Query generator v2: Multi-hop queries and attribute-attribute comparisons

### DIFF
--- a/querygen/README.md
+++ b/querygen/README.md
@@ -1,0 +1,5 @@
+## Query Generator
+
+### Shortcomings
+* attribute comparisons limited to : contains (string), <, >, == and !==
+* does not have concept equality/inequality (eg. = and !=)

--- a/querygen/src/QueryBuilder.java
+++ b/querygen/src/QueryBuilder.java
@@ -96,16 +96,19 @@ public class QueryBuilder {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * @return mapping from attribute type to all the variables corresponding to that attribute type
+     */
     Map<AttributeType<?>, List<Variable>> attributeTypeVariables() {
         Map<AttributeType<?>, List<Variable>> attrTypeMapping = new HashMap<>();
-
-        variableTypeMap.entrySet().stream()
-                .filter(entry -> entry.getValue().isAttributeType())
-                .forEach(entry -> attrTypeMapping.merge(
-                        entry.getValue().asAttributeType(),
-                        Collections.singletonList(entry.getKey()),
-                        (l1, l2) -> Stream.concat(l1.stream(), l2.stream()).collect(Collectors.toList())
-                ));
+        for (Map.Entry<Variable, Type> entry : variableTypeMap.entrySet()) {
+            if (entry.getValue().isAttributeType()) {
+                AttributeType<?> attributeType = entry.getValue().asAttributeType();
+                Variable var = entry.getKey();
+                attrTypeMapping.putIfAbsent(attributeType, new ArrayList<>());
+                attrTypeMapping.get(attributeType).add(var);
+            }
+        }
 
         return attrTypeMapping;
     }

--- a/querygen/src/QueryBuilder.java
+++ b/querygen/src/QueryBuilder.java
@@ -14,9 +14,11 @@ import graql.lang.statement.Variable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -106,6 +108,24 @@ public class QueryBuilder {
                 ));
 
         return attrTypeMapping;
+    }
+
+    Set<Variable> rolePlayersInRelation(Variable relationVariable) {
+        List<Pair<Variable, Role>> pairs = relationRolePlayers.get(relationVariable);
+        if (pairs == null) {
+            return new HashSet<>();
+        } else {
+            return pairs.stream().map(Pair::getFirst).collect(Collectors.toSet());
+        }
+    }
+
+    List<Role> rolesPlayedInRelation(Variable relationVariable) {
+        List<Pair<Variable, Role>> pairs = relationRolePlayers.get(relationVariable);
+        if (pairs == null) {
+            return new ArrayList<>();
+        } else {
+            return pairs.stream().map(Pair::getSecond).collect(Collectors.toList());
+        }
     }
 
     GraqlGet build(GraknClient.Transaction tx, Random random) {

--- a/querygen/src/QueryBuilder.java
+++ b/querygen/src/QueryBuilder.java
@@ -1,26 +1,31 @@
 package grakn.benchmark.querygen;
 
 import grakn.client.GraknClient;
+import grakn.core.concept.type.AttributeType;
 import grakn.core.concept.type.Role;
 import grakn.core.concept.type.Type;
 import graql.lang.Graql;
 import graql.lang.pattern.Pattern;
+import graql.lang.property.ValueProperty;
 import graql.lang.query.GraqlGet;
 import graql.lang.statement.StatementInstance;
 import graql.lang.statement.Variable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class QueryBuilder {
 
     final Map<Variable, Type> variableTypeMap;
     final Map<Variable, List<Variable>> attributeOwnership;
     final Map<Variable, List<Pair<Variable, Role>>> relationRolePlayers;
+    final Map<Variable, Pair<Variable, Graql.Token.Comparator>> attributeComparisons;
 
     final List<Variable> unvisitedVariables;
 
@@ -30,6 +35,7 @@ public class QueryBuilder {
         this.variableTypeMap = new HashMap<>();
         this.attributeOwnership = new HashMap<>();
         this.relationRolePlayers = new HashMap<>();
+        this.attributeComparisons = new HashMap<>();
         this.unvisitedVariables = new ArrayList<>();
     }
 
@@ -53,6 +59,10 @@ public class QueryBuilder {
     void addRolePlayer(Variable relationVar, Variable rolePlayerVariable, Role role) {
         relationRolePlayers.putIfAbsent(relationVar, new ArrayList<>());
         relationRolePlayers.get(relationVar).add(new Pair<>(rolePlayerVariable, role));
+    }
+
+    void addComparison(Variable var1, Variable var2, Graql.Token.Comparator comparator) {
+        attributeComparisons.put(var1, new Pair<>(var2, comparator));
     }
 
     boolean containsVariableWithType(Type type) {
@@ -84,8 +94,24 @@ public class QueryBuilder {
                 .collect(Collectors.toList());
     }
 
+    Map<AttributeType<?>, List<Variable>> attributeTypeVariables() {
+        Map<AttributeType<?>, List<Variable>> attrTypeMapping = new HashMap<>();
+
+        variableTypeMap.entrySet().stream()
+                .filter(entry -> entry.getValue().isAttributeType())
+                .forEach(entry -> attrTypeMapping.merge(
+                        entry.getValue().asAttributeType(),
+                        Collections.singletonList(entry.getKey()),
+                        (l1, l2) -> Stream.concat(l1.stream(), l2.stream()).collect(Collectors.toList())
+                ));
+
+        return attrTypeMapping;
+    }
+
     GraqlGet build(GraknClient.Transaction tx, Random random) {
         List<Pattern> patterns = new ArrayList<>();
+
+        // convert the maps into a graql query, linking connected variables
         for (Variable statementVariable : variableTypeMap.keySet()) {
             Type type = variableTypeMap.get(statementVariable);
             StatementInstance pattern = Graql.var(statementVariable).isa(type.label().toString());
@@ -112,8 +138,15 @@ public class QueryBuilder {
             patterns.add(pattern);
 
         }
+
+        // add attribute - attribute comparisons to the query
+        for (Map.Entry<Variable, Pair<Variable, Graql.Token.Comparator>> attributeComparison : attributeComparisons.entrySet()) {
+            Variable v1 = attributeComparison.getKey();
+            Variable v2 = attributeComparison.getValue().getFirst();
+            Graql.Token.Comparator comparator = attributeComparison.getValue().getSecond();
+            patterns.add(Graql.var(v1).operation(ValueProperty.Operation.Comparison.Variable.of(comparator, Graql.var(v2))));
+        }
+
         return Graql.match(patterns).get();
     }
-
-
 }

--- a/querygen/src/QueryGenerator.java
+++ b/querygen/src/QueryGenerator.java
@@ -22,7 +22,6 @@ import grakn.client.GraknClient;
 import grakn.core.concept.type.AttributeType;
 import grakn.core.concept.type.RelationType;
 import grakn.core.concept.type.Role;
-import grakn.core.concept.type.SchemaConcept;
 import grakn.core.concept.type.Type;
 import graql.lang.Graql;
 import graql.lang.query.GraqlGet;
@@ -30,9 +29,7 @@ import graql.lang.statement.Variable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.management.relation.Relation;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -122,6 +119,7 @@ public class QueryGenerator {
     /**
      * Assign new relations this concept plays a role in, if any. This method allows us to generate multi-hop queries
      * NOTE this method can also generate new variables
+     *
      * @param tx
      * @param variable
      * @param variableType

--- a/querygen/src/QueryGenerator.java
+++ b/querygen/src/QueryGenerator.java
@@ -100,7 +100,7 @@ public class QueryGenerator {
 
 
         // because it's so rare we generate two compatible attributes in a query already,
-        // we can ste the probability of a comparison quite high
+        // we can set the probability of a comparison quite high
         double comparisonGenerateProbability = 0.5;
         double comparisonGenerateProbabilityReduction = 0.5;
         nextProbability = random.nextDouble();

--- a/querygen/src/QueryGenerator.java
+++ b/querygen/src/QueryGenerator.java
@@ -275,7 +275,7 @@ public class QueryGenerator {
 
         // only choose from types that have two ore more vars
         List<AttributeType<?>> possibleAttributeTypes = attributeTypeVariablesMap.entrySet().stream()
-                .filter(entry -> entry.getKey().label().toString().equals("attribute")) // TODO better to check if equals meta type
+                .filter(entry -> !entry.getKey().label().toString().equals("attribute")) // TODO better to check if equals meta type
                 .filter(entry -> entry.getValue().size() > 1)
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toList());

--- a/querygen/src/QueryGenerator.java
+++ b/querygen/src/QueryGenerator.java
@@ -101,9 +101,10 @@ public class QueryGenerator {
             nextProbability = random.nextDouble();
         }
 
-        // TODO add a comparison between compatible attributes with a low probability
 
-        double comparisonGenerateProbability = 0.1;
+        // because it's so rare we generate two compatible attributes in a query already,
+        // we can ste the probability of a comparison quite high
+        double comparisonGenerateProbability = 0.3;
         double comparisonGenerateProbabilityReduction = 0.5;
         nextProbability = random.nextDouble();
 
@@ -130,7 +131,7 @@ public class QueryGenerator {
         // obtain all roles this concept type can play
         List<Role> playableRoles = varType.playing().filter(role -> !role.isImplicit()).collect(Collectors.toList());
 
-        double relationGenerateProbability = 0.5;
+        double relationGenerateProbability = 0.8;
         double relationGenerateProbabilityReduction = 0.5;
         double nextRandom = random.nextDouble();
 
@@ -164,7 +165,7 @@ public class QueryGenerator {
      * We want to use this method to generate a variety of specificity of the roles played
      * So, for a given starting relation type, we first find all roles that can be played by it or its subtypes (down a schema branch)
      * <p>
-     * Then for a random seed role out of this branch, we find all relations that can relate this role
+     * Then for a seed role (which is optionally provided), we find all relations that can relate this role
      * Then proceed to find all unique roles that can be related by these relations (collecting all roles on this branch,
      * filtering out relations on another branch)
      * <p>

--- a/querygen/test-integration/QueryGeneratorIT.java
+++ b/querygen/test-integration/QueryGeneratorIT.java
@@ -90,7 +90,6 @@ public class QueryGeneratorIT {
                 System.out.println(query);
             }
         }
-
     }
 
 
@@ -231,7 +230,27 @@ public class QueryGeneratorIT {
                     }
                 }
             }
+        }
+    }
 
+    @Test
+    public void someQueriesContainComparisons() {
+        try (GraknClient client = new GraknClient(server.grpcUri());
+             GraknClient.Session session = client.session(testKeyspace)) {
+            QueryGenerator queryGenerator = new QueryGenerator(session);
+            // generate 500 queries, some fraction (1/20)? should have
+            int queriesToGenerate = 500;
+            List<GraqlGet> queries = queryGenerator.generate(queriesToGenerate);
+            assertEquals(queries.size(), queriesToGenerate);
+            boolean comparisonFound = false;
+            for (GraqlGet query : queries) {
+                String q = query.toString();
+                if (q.contains("==") || q.contains("!==") || q.contains("<") || q.contains(">")) {
+                    System.out.println(query);
+                    comparisonFound = true;
+                }
+            }
+            assertTrue(comparisonFound);
         }
     }
 

--- a/querygen/test-integration/QueryGeneratorIT.java
+++ b/querygen/test-integration/QueryGeneratorIT.java
@@ -88,6 +88,7 @@ public class QueryGeneratorIT {
             for (GraqlGet query : queries) {
                 assertNotNull(query);
                 System.out.println(query);
+                System.out.print("\n");
             }
         }
     }

--- a/querygen/test-integration/QueryGeneratorIT.java
+++ b/querygen/test-integration/QueryGeneratorIT.java
@@ -87,8 +87,6 @@ public class QueryGeneratorIT {
             assertEquals(queries.size(), queriesToGenerate);
             for (GraqlGet query : queries) {
                 assertNotNull(query);
-                System.out.println(query);
-                System.out.print("\n");
             }
         }
     }
@@ -247,7 +245,6 @@ public class QueryGeneratorIT {
             for (GraqlGet query : queries) {
                 String q = query.toString();
                 if (q.contains("==") || q.contains("!==") || q.contains("<") || q.contains(">")) {
-                    System.out.println(query);
                     comparisonFound = true;
                 }
             }

--- a/querygen/test-integration/QueryGeneratorIT.java
+++ b/querygen/test-integration/QueryGeneratorIT.java
@@ -237,7 +237,7 @@ public class QueryGeneratorIT {
         try (GraknClient client = new GraknClient(server.grpcUri());
              GraknClient.Session session = client.session(testKeyspace)) {
             QueryGenerator queryGenerator = new QueryGenerator(session);
-            // generate 500 queries, some fraction (1/20)? should have
+            // generate 500 queries, some fraction (1/20)? should have comparisons
             int queriesToGenerate = 500;
             List<GraqlGet> queries = queryGenerator.generate(queriesToGenerate);
             assertEquals(queries.size(), queriesToGenerate);


### PR DESCRIPTION
## What is the goal of this PR?
Make the query generator more sophisticated by adding two new extensions: 1) the ability to generate multi-hop queries (attaching a new relation to any concept chosen, based on the roles it's allowed to play) and 2) adding the occasional attribute-attribute comparison when two compatible attributes are found

## What are the changes implemented in this PR?
* Implement attribute-attribute comparisons between variables (no constants yet)
* Allow generating much longer multi-hop queries and adjust the probabilities (based on exponential decay) to generate a higher rate of multi-hop queries. Note that this new  generates new vars that are not included in the top level exponential decay
* Making naming consistent between use of `var` and `variable`
* Fix bug related to reusing variables as a role player in a relation