### PR TITLE
Fix Reasoner Benchmark Queries

### DIFF
--- a/common/configuration/scenario/reasoning/queries_read.yml
+++ b/common/configuration/scenario/reasoning/queries_read.yml
@@ -10,7 +10,7 @@ queries:
   - "match (from: $x, to: $y) isa transRelation; get;"
 
   # transitive closure with a bound
-  - "match (from: $x, to: $y) isa transRelation;$x has index 'start'; get;"
+  - "match (from: $x, to: $y) isa transRelation; $x has nonInferredAttribute 'start'; get;"
 
   # limited transitive closure
   - "match (from: $x, to: $y) isa transRelation; get; limit 1000;"


### PR DESCRIPTION
## What is the goal of this PR?
Fix a query that was being benchmarked using reasoner, where the wrong attribute label was being used.

## What are the changes implemented in this PR?
* change attribute label from one that is a `Long` to one that is a `String`