### PR TITLE
Disable cassandra caches and JVM JITs

### DIFF
--- a/service/web-server/resources/execute.sh
+++ b/service/web-server/resources/execute.sh
@@ -37,9 +37,14 @@ bazel build //:assemble-linux-targz
 cd bazel-genfiles
 tar -xf grakn-core-all-linux.tar.gz
 
-# start grakn
+# configure and start grakn
 cd grakn-core-all-linux
-./grakn server start --benchmark
+
+# current server options to stabilise the variance include disabling the JITs and cassandra caches
+chmod +x server/conf/grakn.properties
+echo "storage.internal.counter_cache_size_in_mb=0" >> server/conf/grakn.properties
+echo "storage.internal.key_cache_size_in_mb=0" >> server/conf/grakn.properties
+SERVER_JAVAOPTS='-Xint' STORAGE_JAVAOPTS='-Xint' ./grakn server start --benchmark
 
 # clone, build and unzip grakn
 cd ~


### PR DESCRIPTION
## What is the goal of this PR?
One of the current issues with benchmark-ci is that the variance is too large to provide useful feedback. There are two types of variance: variance between commits, and variance between executions of repeated queries. This PR addresses the variance between the repetitions of each query.

## What are the changes implemented in this PR?
* Disable JITs - the JITs introduce a large overhead with the first few executions of queries, then provide about 4-6x speedup over pure interpreted code (at first glance). This leads to slow first queries and very fast second queries (1s to 50ms difference, while interpeter only is at 200ms in one example) and in turn a very large variance.
* Disable cassandra caches for the same reason as above