### PR TITLE
Remove http:// from zipkin launch and Open Zipkin port

### DIFF
--- a/service/web-server/resources/execute.sh
+++ b/service/web-server/resources/execute.sh
@@ -56,7 +56,7 @@ unzip -o profiler.zip
 
 # run zipkin
 cd profiler
-tmux new-session -d -s zipkin "STORAGE_TYPE=elasticsearch ES_HOSTS=http://$ES_URI ES_INDEX=benchmark java -jar external-dependencies/zipkin.jar"
+tmux new-session -d -s zipkin "STORAGE_TYPE=elasticsearch ES_HOSTS=$ES_URI ES_INDEX=benchmark java -jar external-dependencies/zipkin.jar"
 
 
 # mark execution as running

--- a/service/web-server/src/execution/vmClient/index.ts
+++ b/service/web-server/src/execution/vmClient/index.ts
@@ -28,6 +28,7 @@ export function VMController(execution: IExecution) {
     this.project = 'grakn-dev';
     this.machineType = 'n1-standard-16';
     this.imageName = 'benchmark-executor-image-2';
+    this.tags = ['zipkin-9411'];
     this.esUri = `${config.es.host}:${config.es.port}`;
     this.webUri = `${config.web.host}`;
     this.logPath = config.logPath;
@@ -50,6 +51,7 @@ async function start() {
                     `https://www.googleapis.com/compute/v1/projects/${this.project}/global/images/${this.imageName}`,
             },
         }],
+        tags: this.tags,
         // this config assigns an external IP to the VM instance which is required for ssh access
         networkInterfaces: [{ accessConfigs: [{}] }],
     };


### PR DESCRIPTION
## What is the goal of this PR?
Progress on fixing benchmark executors' persistence issues by removing incorrect `http://` from the zipkin launch command. Also expose the zipkin port (9411) externally to aid debugging

## What are the changes implemented in this PR?
* Remove `http://` 
* Add open port to export Zipkin for debugging