### PR TITLE
Fix grakn.properties Permissions

### DIFF
--- a/service/web-server/resources/execute.sh
+++ b/service/web-server/resources/execute.sh
@@ -42,6 +42,7 @@ cd grakn-core-all-linux
 
 # current server options to stabilise the variance include disabling the JITs and cassandra caches
 chmod a+rwx server/conf/grakn.properties
+echo "" >> server/conf/grakn.properties # add a new line just in case we join lines together
 echo "storage.internal.counter_cache_size_in_mb=0" >> server/conf/grakn.properties
 echo "storage.internal.key_cache_size_in_mb=0" >> server/conf/grakn.properties
 SERVER_JAVAOPTS='-Xint' STORAGE_JAVAOPTS='-Xint' ./grakn server start --benchmark

--- a/service/web-server/resources/execute.sh
+++ b/service/web-server/resources/execute.sh
@@ -41,7 +41,7 @@ tar -xf grakn-core-all-linux.tar.gz
 cd grakn-core-all-linux
 
 # current server options to stabilise the variance include disabling the JITs and cassandra caches
-chmod +x server/conf/grakn.properties
+chmod a+rwx server/conf/grakn.properties
 echo "storage.internal.counter_cache_size_in_mb=0" >> server/conf/grakn.properties
 echo "storage.internal.key_cache_size_in_mb=0" >> server/conf/grakn.properties
 SERVER_JAVAOPTS='-Xint' STORAGE_JAVAOPTS='-Xint' ./grakn server start --benchmark


### PR DESCRIPTION
## What is the goal of this PR?
Change from `+x` to `a+rwx` so that the script can disable cassandra caches.
Also insert a new line when modifying `grakn.properties` to avoid accidentally merging lines together

## What are the changes implemented in this PR?
* Fix bug with wrong permissions
* echo extra newline