### PR TITLE
GCP Disk Autodelete and Bazel clean before grakn Build in execute.sh

### DIFF
--- a/service/web-server/resources/execute.sh
+++ b/service/web-server/resources/execute.sh
@@ -33,6 +33,7 @@ cd ~
 git clone $GRAKN_REPOSITORY_URL
 cd grakn
 git checkout $COMMIT
+bazel clean --expunge  # clean caches just in case
 bazel build //:assemble-linux-targz
 cd bazel-genfiles
 tar -xf grakn-core-all-linux.tar.gz
@@ -51,6 +52,7 @@ SERVER_JAVAOPTS='-Xint' STORAGE_JAVAOPTS='-Xint' ./grakn server start --benchmar
 cd ~
 git clone https://github.com/graknlabs/benchmark.git
 cd benchmark
+bazel clean --expunge
 bazel build //:profiler-distribution
 cd bazel-genfiles
 unzip -o profiler.zip

--- a/service/web-server/resources/execute.sh
+++ b/service/web-server/resources/execute.sh
@@ -33,6 +33,7 @@ cd ~
 git clone $GRAKN_REPOSITORY_URL
 cd grakn
 git checkout $COMMIT
+echo "Cleaning bazel cache"
 bazel clean --expunge  # clean caches just in case
 bazel build //:assemble-linux-targz
 cd bazel-genfiles

--- a/service/web-server/resources/execute.sh
+++ b/service/web-server/resources/execute.sh
@@ -33,9 +33,14 @@ cd ~
 git clone $GRAKN_REPOSITORY_URL
 cd grakn
 git checkout $COMMIT
+
+# steps to reduce occurence of bazel JVM file not found error
+sleep 5
 echo "Cleaning bazel cache"
-bazel clean --expunge  # clean caches just in case
+export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
+bazel clean --expunge
 bazel build //:assemble-linux-targz
+
 cd bazel-genfiles
 tar -xf grakn-core-all-linux.tar.gz
 

--- a/service/web-server/src/execution/vmClient/index.ts
+++ b/service/web-server/src/execution/vmClient/index.ts
@@ -46,6 +46,7 @@ async function start() {
         machineType: this.machineType,
         disks: [{
             boot: true,
+            autoDelete: true,
             initializeParams: {
                 sourceImage:
                     `https://www.googleapis.com/compute/v1/projects/${this.project}/global/images/${this.imageName}`,


### PR DESCRIPTION
## What is the goal of this PR?
Benchmark builds are failing due the following error:
```
INFO: Analyzed target //:assemble-linux-targz (508 packages loaded, 2798 targets configured).
INFO: Found 1 target...
ERROR: missing input file '@local_jdk//:jre/lib/amd64/server/classes.jsa'
ERROR: /home/ubuntu/.cache/bazel/_bazel_ubuntu/490c8da38bc09af05d455a845f491ad6/external/bazel_tools/tools/jdk/BUILD:306:1: @bazel_tools//tools/jdk:platformclasspath: missing input file '@local_jdk//:jre/lib/amd64/server/classes.jsa'
ERROR: /home/ubuntu/.cache/bazel/_bazel_ubuntu/490c8da38bc09af05d455a845f491ad6/external/bazel_tools/tools/jdk/BUILD:306:1 1 input file(s) do not exist
INFO: Elapsed time: 56.512s, Critical Path: 0.05s
```

To protect against this we add steps like bazel cleans, set JAVA_HOME, and also make sure disks are deleted and recreated on every GCP instance creation to avoid stale bazel caches which is suspected to be one of the sources of this error.

## What are the changes implemented in this PR?
* Add sleep, bazel clean, and JAVA_HOME in `execute.sh`
* Set disk autodelete to be true