### PR TITLE
Reduce benchmark repetitions

### DIFF
--- a/common/configuration/scenario/attribute/attribute_read_config.yml
+++ b/common/configuration/scenario/attribute/attribute_read_config.yml
@@ -6,7 +6,7 @@ scales:
   - 1000
   - 3000
   - 5000
-repeatsPerQuery: 10
+repeatsPerQuery: 4
 
 queries: "queries_read.yml"
 deleteInsertedConcepts: true

--- a/common/configuration/scenario/biochemical_network/biochemical_config_read.yml
+++ b/common/configuration/scenario/biochemical_network/biochemical_config_read.yml
@@ -6,7 +6,7 @@ scales:
   - 2000
   - 4000
   - 6000 # large number of role players => slow at large scales
-repeatsPerQuery: 10
+repeatsPerQuery: 4
 
 queries: "queries_read.yml"
 deleteInsertedConcepts: true

--- a/common/configuration/scenario/complex/config_read.yml
+++ b/common/configuration/scenario/complex/config_read.yml
@@ -7,7 +7,7 @@ scales:
   - 400
 #  - 600
 
-repeatsPerQuery: 5
+repeatsPerQuery: 4
 
 queries: "queries_complex_read.yml"
 deleteInsertedConcepts: true

--- a/common/configuration/scenario/complex/config_write.yml
+++ b/common/configuration/scenario/complex/config_write.yml
@@ -6,7 +6,7 @@ scales:
   - 2000
   - 8000
 
-repeatsPerQuery: 5
+repeatsPerQuery: 4
 
 queries: "queries_complex_write.yml"
 deleteInsertedConcepts: true

--- a/common/configuration/scenario/road_network/road_config_read.yml
+++ b/common/configuration/scenario/road_network/road_config_read.yml
@@ -7,7 +7,7 @@ scales:
   - 4000
   - 8000
 
-repeatsPerQuery: 10
+repeatsPerQuery: 5
 
 queries: "queries_read.yml"
 deleteInsertedConcepts: true

--- a/common/configuration/scenario/schema/data_definition_config.yml
+++ b/common/configuration/scenario/schema/data_definition_config.yml
@@ -2,7 +2,7 @@ name: "Data Definition"
 description: "Test defining, undefining, and querying schema elements against a 1k line schema (from docs)"
 dataGenerator: "none"
 schema: "data_definition_schema.gql"
-repeatsPerQuery: 30
+repeatsPerQuery: 4
 
 queries: "queries.yml"
 deleteInsertedConcepts: true

--- a/service/web-server/resources/execute.sh
+++ b/service/web-server/resources/execute.sh
@@ -40,6 +40,8 @@ echo "Cleaning bazel cache"
 export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 bazel clean --expunge
 bazel build //:assemble-linux-targz
+# build twice TODO fix if the `missing input file '@local_jdk//:jre/lib...` can be tracked down and resolved
+bazel build //:assemble-linux-targz
 
 cd bazel-genfiles
 tar -xf grakn-core-all-linux.tar.gz


### PR DESCRIPTION
## What is the goal of this PR?
Benchmark-ci takes ages to run since disabling the JIT mechanisms. This is made worse by having between 10 and 30 repetitions per query.  Here we reduce the repetitions as much as possible to see results more quickly.

Also add another rebuild step to avoid the `missing input file '@local_jdk//:jre/lib/...` error

## What are the changes implemented in this PR?
reduce repetitions of each scenario