### PR TITLE
Adds Long type support to GraphQL

### DIFF
--- a/service/web-server/src/graphqlTypes.ts
+++ b/service/web-server/src/graphqlTypes.ts
@@ -1,0 +1,29 @@
+import { GraphQLScalarType } from 'graphql';
+import { Kind } from 'graphql/language';
+
+// GraphQL 52-bit signed integer type
+const MAX_LONG = Number.MAX_SAFE_INTEGER
+const MIN_LONG = Number.MIN_SAFE_INTEGER
+
+const coerceLong = (value) => {
+    if (value == '') throw new TypeError('Long cannot represent non 52-bit signed integer value: (empty string)');
+    const num = Number(value);
+    if (num === num && num <= MAX_LONG && num >= MIN_LONG) return num < 0 ? Math.ceil(num) : Math.floor(num);
+    throw new TypeError('Long cannot represent non 52-bit signed integer value: ' + String(value));
+}
+
+const parseLiteral = (ast) => {
+    if (ast.kind == Kind.INT) {
+        const num = parseInt(ast.value, 10);
+        if (num <= MAX_LONG && num >= MIN_LONG) return num;
+    }
+    return null
+}
+
+export const GraphQLLong = new GraphQLScalarType({
+    name: 'Long',
+    description: 'The `Long` scalar type represents 52-bit integers',
+    serialize: coerceLong,
+    parseValue: coerceLong,
+    parseLiteral: parseLiteral
+});

--- a/service/web-server/src/graphqlTypes.ts
+++ b/service/web-server/src/graphqlTypes.ts
@@ -1,29 +1,31 @@
+// this code has been copied over from `graphql-type-long` (https://github.com/chadlieberman/graphql-type-long/blob/master/src/index.coffee)
 import { GraphQLScalarType } from 'graphql';
 import { Kind } from 'graphql/language';
 
 // GraphQL 52-bit signed integer type
-const MAX_LONG = Number.MAX_SAFE_INTEGER
-const MIN_LONG = Number.MIN_SAFE_INTEGER
+const MAX_LONG = Number.MAX_SAFE_INTEGER;
+const MIN_LONG = Number.MIN_SAFE_INTEGER;
 
 const coerceLong = (value) => {
     if (value == '') throw new TypeError('Long cannot represent non 52-bit signed integer value: (empty string)');
     const num = Number(value);
-    if (num === num && num <= MAX_LONG && num >= MIN_LONG) return num < 0 ? Math.ceil(num) : Math.floor(num);
+    if (num <= MAX_LONG && num >= MIN_LONG) return num < 0 ? Math.ceil(num) : Math.floor(num);
     throw new TypeError('Long cannot represent non 52-bit signed integer value: ' + String(value));
 }
 
+// we need to gain a better understanding of what this function is responsible for
 const parseLiteral = (ast) => {
     if (ast.kind == Kind.INT) {
         const num = parseInt(ast.value, 10);
         if (num <= MAX_LONG && num >= MIN_LONG) return num;
     }
-    return null
+    return null;
 }
 
 export const GraphQLLong = new GraphQLScalarType({
     name: 'Long',
     description: 'The `Long` scalar type represents 52-bit integers',
-    serialize: coerceLong,
-    parseValue: coerceLong,
-    parseLiteral: parseLiteral
+    serialize: coerceLong, // gets invoked when serializing the result to send it back to a client.
+    parseValue: coerceLong, // gets invoked to parse client input that was passed through variables.
+    parseLiteral: parseLiteral // gets invoked to parse client input that was passed inline in the query.
 });

--- a/service/web-server/src/span/controller.ts
+++ b/service/web-server/src/span/controller.ts
@@ -3,7 +3,7 @@ import { Client as IEsClient, RequestParams } from '@elastic/elasticsearch';
 import { limitResults } from '../utils';
 import { GraphQLSchema } from 'graphql';
 import { makeExecutableSchema } from 'graphql-tools';
-
+import { GraphQLLong } from '../graphqlTypes';
 
 const ES_PAYLOAD_COMMON = { index: 'benchmark*', type: 'span' };
 
@@ -28,6 +28,8 @@ function getGraphqlServer(): graphqlHTTP.Middleware {
 }
 
 const typeDefs = `
+  scalar Long
+
   type Query {
     querySpans(
         parentId: String,
@@ -50,7 +52,7 @@ const typeDefs = `
 
   type ChildSpan {
     id: String!
-    duration: Int!
+    duration: Long!
     name: String!
     timestamp: String
     tags: ChildSpanTag
@@ -63,7 +65,7 @@ const typeDefs = `
 
   type ExecutionSpan {
     id: String!
-    duration: Int!
+    duration: Long!
     name: String!
     tags: ExecutionSpanTag
   }
@@ -81,7 +83,7 @@ const typeDefs = `
   type QuerySpan {
     id: String!
     parentId: String
-    duration: Int!
+    duration: Long!
     name: String!
     tags: QuerySpanTag
   }
@@ -95,6 +97,7 @@ const typeDefs = `
 `;
 
 const resolvers = {
+    Long: GraphQLLong,
     Query: {
         querySpans: async (object, args, context, ) => {
             const filterResults = (args) => {


### PR DESCRIPTION
## What is the goal of this PR?
Due to the recent https://github.com/graknlabs/benchmark/pull/313, the duration value of a span may now exceed the maximum integer value (32-bit) supported by GraphQL. For this reason, we've added the `Long` GraphQL type to represent the type of `duration` in our GraphQL schemas.

## What are the changes implemented in this PR?
- `Long` type is created to represent 52-bit signed integer values.
-  the `Long` type is assigned to the `dutation` property of `ChildSpan`, `ExecutionSpan` and `QuerySpan` type definitions.