### PR TITLE
Fix test and reduce QueryGenerator nondeterminism

### DIFF
--- a/querygen/src/SchemaWalker.java
+++ b/querygen/src/SchemaWalker.java
@@ -22,6 +22,7 @@ import grakn.client.GraknClient;
 import grakn.core.concept.type.Type;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -35,14 +36,20 @@ class SchemaWalker {
      * @return some type that is a subtype of rootType
      */
     static Type walkSubs(Type rootType, Random random) {
-        List<Type> subs = rootType.subs().collect(Collectors.toList());
+        List<Type> subs = rootType.subs()
+                .sorted(Comparator.comparing(type -> type.label().toString()))
+                .collect(Collectors.toList());
         int index = random.nextInt(subs.size());
         return subs.get(index);
     }
 
     static Type walkSupsNoMeta(GraknClient.Transaction tx, Type ownableAttribute, Random random) {
         Type metaConcept = tx.getMetaConcept();
-        List<? extends Type> nonMetaSups = ownableAttribute.sups().filter(type -> !type.equals(metaConcept)).collect(Collectors.toList());
+        List<? extends Type> nonMetaSups = ownableAttribute.sups()
+                .filter(type -> !type.equals(metaConcept))
+                .sorted(Comparator.comparing(type -> type.label().toString()))
+                .collect(Collectors.toList());
+
 
         int index = random.nextInt(nonMetaSups.size());
         return nonMetaSups.get(index);

--- a/querygen/test-integration/BUILD
+++ b/querygen/test-integration/BUILD
@@ -35,7 +35,7 @@ java_test(
          "//querygen/test-integration/conf:grakn.properties",
          "//querygen/test-integration/resources:schema.gql"
      ],
-     size = "medium"
+     size = "large"
  )
 
 

--- a/querygen/test-integration/BUILD
+++ b/querygen/test-integration/BUILD
@@ -34,7 +34,8 @@ java_test(
          "//querygen/test-integration/conf:cassandra-embedded.yaml",
          "//querygen/test-integration/conf:grakn.properties",
          "//querygen/test-integration/resources:schema.gql"
-     ]
+     ],
+     size = "medium"
  )
 
 

--- a/querygen/test-integration/QueryGeneratorIT.java
+++ b/querygen/test-integration/QueryGeneratorIT.java
@@ -231,7 +231,7 @@ public class QueryGeneratorIT {
     }
 
     /**
-     * TODO test to check that attribute comparisons are compatiblet
+     * TODO test to check that attribute comparisons are compatible
       */
     @Test
     public void attributeComparisonsBetweenSameDatatypes() {

--- a/querygen/test-integration/QueryGeneratorIT.java
+++ b/querygen/test-integration/QueryGeneratorIT.java
@@ -243,8 +243,8 @@ public class QueryGeneratorIT {
         try (GraknClient client = new GraknClient(server.grpcUri());
              GraknClient.Session session = client.session(testKeyspace)) {
             QueryGenerator queryGenerator = new QueryGenerator(session);
-            // generate 500 queries, some fraction (1/20)? should have comparisons
-            int queriesToGenerate = 500;
+            // generate 300 queries, some fraction (1/20)? should have comparisons
+            int queriesToGenerate = 300;
             List<GraqlGet> queries = queryGenerator.generate(queriesToGenerate);
             assertEquals(queries.size(), queriesToGenerate);
             boolean comparisonFound = false;

--- a/querygen/test-integration/conf/grakn.properties
+++ b/querygen/test-integration/conf/grakn.properties
@@ -23,7 +23,7 @@
 # A larger sharding threshold will increase runtime as the knowledge base  grows and decrease
 # the likelihood of supernodes. A threshold that is too small will create supernodes
 # more frequently.
-knowledge-base.sharding-threshold=10000
+knowledge-base.type-shard-threshold=250000
 
 ############################# Server Configuration #############################
 


### PR DESCRIPTION
## What is the goal of this PR?
CircleCI has been failing benchmark integration tests because a entry in `grakn.properties` was misnamed after a change in Grakn Core:
`knowledge-base.sharding-threshold=10000`
became
`knowledge-base.type-shard-threshold=250000`

## What are the changes implemented in this PR?
* Change `grakn.properties` property to correct key
* Introduce two sort() methods to try to reduce test flakiness