### PR TITLE
Prepare for bazel upgrade

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,3 @@
-build --java_toolchain @graknlabs_build_tools//bazel:java-toolchain
 build:rbe --project_id=grakn-dev
 build:rbe --remote_instance_name=projects/grakn-dev/instances/default_instance
 build:rbe --remote_cache=remotebuildexecution.googleapis.com


### PR DESCRIPTION
## What is the goal of this PR?

Bazel upgrade to `0.29.0` planned across all repos is going to break all CI because newest version doesn't work with our custom Java toolchain (due to bazelbuild/bazel#8659). However, we found a different way to approach the original problem (described in bazelbuild/bazel#8277) which is modifying the IntelliJ Bazel plugin. This solution does not require custom Java toolchain and therefore it'll be removed.

## What are the changes implemented in this PR?

Stop using custom `java_toolchain` [with modified `singlejar` binary] for all builds
