### PR TITLE
Fix CI by no longer depending on non-existent library

### DIFF
--- a/generator/BUILD
+++ b/generator/BUILD
@@ -5,7 +5,6 @@ java_library(
         "//common/timer:timer",
 
         "@graknlabs_client_java//:client-java",
-        "@graknlabs_grakn_core//api:api",
         "@graknlabs_grakn_core//common:common",
         "@graknlabs_grakn_core//concept:concept",
         "@graknlabs_graql//java:graql",

--- a/metric/BUILD
+++ b/metric/BUILD
@@ -48,7 +48,6 @@ java_library(
     srcs = glob(["*.java"]),
     deps = [
         "@graknlabs_client_java//:client-java",
-        "@graknlabs_grakn_core//api:api",
         "@graknlabs_graql//java:graql",
         "@graknlabs_grakn_core//concept:concept",
 
@@ -85,7 +84,6 @@ java_test(
          "//metric:metric",
          "//dependencies/maven/artifacts/junit:junit",
         "@graknlabs_client_java//:client-java",
-        "@graknlabs_grakn_core//api:api",
         "@graknlabs_grakn_core//concept:concept",
         "@graknlabs_graql//java:graql"
      ],
@@ -118,7 +116,6 @@ java_test(
          "//metric:metric",
          "//dependencies/maven/artifacts/junit:junit",
         "@graknlabs_client_java//:client-java",
-        "@graknlabs_grakn_core//api:api",
         "@graknlabs_grakn_core//concept:concept",
         "@graknlabs_graql//java:graql",
      ],
@@ -145,7 +142,6 @@ java_test(
         "//dependencies/maven/artifacts/junit:junit",
         "@graknlabs_graql//java:graql",
         "@graknlabs_client_java//:client-java",
-        "@graknlabs_grakn_core//api:api",
     ],
     data = [":test/binaryGraph.csv", ":test/unaryBinaryGraph.csv"],
 )

--- a/profiler/src/BUILD
+++ b/profiler/src/BUILD
@@ -28,7 +28,6 @@ java_library(
 
         "@graknlabs_client_java//:client-java",
         "@graknlabs_graql//java:graql",
-        "@graknlabs_grakn_core//api:api",
         "@graknlabs_grakn_core//concept:concept",
 
         # together these can be used to create clients with tracing enabled

--- a/querygen/src/BUILD
+++ b/querygen/src/BUILD
@@ -22,7 +22,6 @@ java_library(
     deps = [
         "@graknlabs_client_java//:client-java",
         "@graknlabs_graql//java:graql",
-        "@graknlabs_grakn_core//api:api",
         "@graknlabs_grakn_core//concept:concept",
 
         # together these can be used to create clients with tracing enabled

--- a/report/producer/BUILD
+++ b/report/producer/BUILD
@@ -29,7 +29,6 @@ java_library(
         "//common/timer:timer",
 
         "@graknlabs_client_java//:client-java",
-        "@graknlabs_grakn_core//api:api",
         "@graknlabs_graql//java:graql",
         "@graknlabs_grakn_core//concept:concept",
 


### PR DESCRIPTION
## What is the goal of this PR?

graknlabs/grakn#5460 removed `//api` package from Grakn Core sources. This PR removes the dependency on `@graknlabs_grakn_core//api:api`

## What are the changes implemented in this PR?

Remove `@graknlabs_grakn_core//api:api` from `deps` everywhere