### PR TITLE
Adapt to delete queries returning Void

### DIFF
--- a/report/producer/AnswerAnalysis.java
+++ b/report/producer/AnswerAnalysis.java
@@ -21,7 +21,6 @@ package grakn.benchmark.report.producer;
 import grakn.client.answer.Answer;
 import grakn.client.answer.AnswerGroup;
 import grakn.client.answer.ConceptMap;
-import grakn.client.answer.ConceptSet;
 import grakn.client.answer.Void;
 import graql.lang.query.GraqlCompute;
 import graql.lang.query.GraqlDelete;
@@ -62,7 +61,7 @@ public class AnswerAnalysis {
         return baseRoundTrips + answer.size();
     }
 
-    static int countRoundTripsCompleted(GraqlDelete deleteQuery, Void answer) {
+    public static int countRoundTripsCompleted(GraqlDelete deleteQuery, Void answer) {
         return 2;
     }
 

--- a/report/producer/AnswerAnalysis.java
+++ b/report/producer/AnswerAnalysis.java
@@ -22,6 +22,7 @@ import grakn.client.answer.Answer;
 import grakn.client.answer.AnswerGroup;
 import grakn.client.answer.ConceptMap;
 import grakn.client.answer.ConceptSet;
+import grakn.client.answer.Void;
 import graql.lang.query.GraqlCompute;
 import graql.lang.query.GraqlDelete;
 import graql.lang.query.GraqlGet;
@@ -40,10 +41,6 @@ public class AnswerAnalysis {
                 .map(conceptMap -> conceptMap.map().size())
                 .reduce((a,b) -> a+b)
                 .orElse(0);
-    }
-
-    static int countDeletedConcepts(GraqlDelete deleteQuery, ConceptSet answer) {
-        return answer.set().size();
     }
 
     public static int computedConcepts(GraqlCompute computeQuery, List<? extends Answer> answer) {
@@ -65,7 +62,7 @@ public class AnswerAnalysis {
         return baseRoundTrips + answer.size();
     }
 
-    static int countRoundTripsCompleted(GraqlDelete deleteQuery, ConceptSet answer) {
+    static int countRoundTripsCompleted(GraqlDelete deleteQuery, Void answer) {
         return 2;
     }
 

--- a/report/producer/QueriesExecutor.java
+++ b/report/producer/QueriesExecutor.java
@@ -22,7 +22,6 @@ import grakn.benchmark.report.producer.container.QueryExecutionResults;
 import grakn.client.GraknClient;
 import grakn.client.answer.AnswerGroup;
 import grakn.client.answer.ConceptMap;
-import grakn.client.answer.ConceptSet;
 import grakn.client.answer.Numeric;
 import grakn.client.answer.Void;
 import grakn.client.concept.Concept;

--- a/report/producer/QueriesExecutor.java
+++ b/report/producer/QueriesExecutor.java
@@ -24,6 +24,7 @@ import grakn.client.answer.AnswerGroup;
 import grakn.client.answer.ConceptMap;
 import grakn.client.answer.ConceptSet;
 import grakn.client.answer.Numeric;
+import grakn.client.answer.Void;
 import grakn.client.concept.Concept;
 import graql.lang.Graql;
 import graql.lang.query.GraqlCompute;
@@ -103,12 +104,10 @@ class QueriesExecutor implements Callable<Map<GraqlQuery, QueryExecutionResults>
                     queryType = "delete";
 
                     startTime = System.currentTimeMillis();
-                    ConceptSet answer = tx.stream(query.asDelete()).findFirst().get();
+                    Void answer = tx.stream(query.asDelete()).findFirst().get();
                     endTime = System.currentTimeMillis();
 
                     roundTrips = AnswerAnalysis.countRoundTripsCompleted(query.asDelete(), answer);
-                    conceptsHandled = AnswerAnalysis.countDeletedConcepts(query.asDelete(), answer);
-
                 } else if (query instanceof GraqlCompute) {
                     queryType = "compute";
 


### PR DESCRIPTION
## What is the goal of this PR?

Delete query now returns `Void` type (graknlabs/protocol#18, graknlabs/grakn#5475) which means `benchmark` needs to adapt.

## What are the changes implemented in this PR?

* number of deleted concepts is no longer returned, so `AnswerAnalysis. countDeletedConcepts` is removed
* `GraqlDelete` query now returns `Void` instead of `ConceptSet`
* `AnswerAnalysis.countRoundTripsCompleted` now accepts `grakn.client.answer.Void` as an argument instead of `ConceptSet`
